### PR TITLE
Restore places dataset + search from any US ZIP code

### DIFF
--- a/backend/data/places.json
+++ b/backend/data/places.json
@@ -1,11 +1,22203 @@
 {
- "generatedAt": "2026-08-18T00:58:22.088Z",
+ "generatedAt": "2026-08-18T01:04:34.370Z",
  "center": {
-  "lat": null,
+  "lat": 40.6084,
   "lng": -75.4902
  },
  "radiusMeters": 20000,
  "attribution": "© OpenStreetMap contributors (ODbL)",
- "count": 0,
- "places": []
+ "count": 1032,
+ "places": [
+  {
+   "id": "node/13022129387",
+   "name": "12th Street Tavern",
+   "address": "247 North 12th Street, Allentown, PA",
+   "lat": 40.6036281,
+   "lng": -75.4835483,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022129387"
+  },
+  {
+   "id": "node/12692199284",
+   "name": "1500 Bar and Grill",
+   "address": "1500 MacArthur Road, Allentown, PA",
+   "lat": 40.6258088,
+   "lng": -75.487375,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12692199284"
+  },
+  {
+   "id": "node/3924684307",
+   "name": "1741 on the Terrace",
+   "address": "437 Main Street, Bethlehem, PA",
+   "lat": 40.6200628,
+   "lng": -75.3822752,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3924684307"
+  },
+  {
+   "id": "way/696979778",
+   "name": "1760 Pub N Grille",
+   "address": "1176 Trexlertown Road, Trexlertown, PA",
+   "lat": 40.5475904,
+   "lng": -75.6059051,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108413311",
+   "website": "https://www.1760pubandgrille.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/696979778"
+  },
+  {
+   "id": "way/1310607842",
+   "name": "2 Brothers Pizzeria & Restaurant",
+   "address": "5757 PA 145, Laurys Station, PA",
+   "lat": 40.7302755,
+   "lng": -75.5330069,
+   "types": [
+    "restaurant",
+    "pizza",
+    "italian"
+   ],
+   "cuisine": [
+    "pizza",
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104400868",
+   "website": "https://www.2brotherspizzeria.com/",
+   "openingHours": "11:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1310607842"
+  },
+  {
+   "id": "node/367905924",
+   "name": "24 East",
+   "address": "24",
+   "lat": 40.6118717,
+   "lng": -75.3777478,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/367905924"
+  },
+  {
+   "id": "node/9875328307",
+   "name": "2nd Street Tavern",
+   "address": "33 North 2nd Street, Coplay, PA",
+   "lat": 40.6737237,
+   "lng": -75.4921677,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9875328307"
+  },
+  {
+   "id": "node/6077547585",
+   "name": "3 Men & A Bagel",
+   "address": "7150 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5475215,
+   "lng": -75.5971223,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-366-9520",
+   "website": "https://3menandabagel.net/",
+   "openingHours": "Mo-Fr 06:00-15:00; Sa 07:00-15:00; Su 07:00-14:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6077547585"
+  },
+  {
+   "id": "node/7685089155",
+   "name": "3 Men and a Bagel",
+   "address": "3350 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6591976,
+   "lng": -75.4185695,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685089155"
+  },
+  {
+   "id": "node/3566468436",
+   "name": "50 Yard Line Sports Bar",
+   "address": "2626 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6441972,
+   "lng": -75.3456008,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3566468436"
+  },
+  {
+   "id": "way/268712961",
+   "name": "50 Yard Line Sports Bar & Pizza Como",
+   "address": "2626 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6442424,
+   "lng": -75.3457041,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/268712961"
+  },
+  {
+   "id": "node/4886221860",
+   "name": "515 Main",
+   "address": "515 Main Street, Bethlehem, PA",
+   "lat": 40.6210026,
+   "lng": -75.3822229,
+   "types": [
+    "bar",
+    "american",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4886221860"
+  },
+  {
+   "id": "node/6940435989",
+   "name": "7th St. Family Restaurant",
+   "address": "802 North 7th Street, Allentown",
+   "lat": 40.6135112,
+   "lng": -75.4773295,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "http://orderfamilyrestaurant7thstreet.mobile-webview8.com/",
+   "openingHours": "Mo-Sa 09:00-21:00; Su 09:00-17:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6940435989"
+  },
+  {
+   "id": "node/6943158019",
+   "name": "7th Street Rotisserie Chicken",
+   "address": "",
+   "lat": 40.6101916,
+   "lng": -75.4752921,
+   "types": [
+    "fast_food",
+    "chicken"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158019"
+  },
+  {
+   "id": "node/11820457510",
+   "name": "88 Pot",
+   "address": "3926 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6733135,
+   "lng": -75.3416718,
+   "types": [
+    "restaurant",
+    "korean"
+   ],
+   "cuisine": [
+    "korean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11820457510"
+  },
+  {
+   "id": "node/4633667495",
+   "name": "904 West Restaurant & Lounge",
+   "address": "904 Hamilton Street, Allentown",
+   "lat": 40.6009337,
+   "lng": -75.4758091,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4633667495"
+  },
+  {
+   "id": "node/5851415243",
+   "name": "99 Bottles",
+   "address": "701 Hamilton Street, Allentown, PA",
+   "lat": 40.6019688,
+   "lng": -75.4732296,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.the99bottles.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5851415243"
+  },
+  {
+   "id": "node/7935299276",
+   "name": "A-1 Hibachi Steakhouse",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5577772,
+   "lng": -75.4909555,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-709-0998",
+   "website": "https://www.a1steakhouseallentown.com/location.html",
+   "openingHours": "Mo-Th 11:00-21:00; Fr-Sa 11:00-21:30; Su 12:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7935299276"
+  },
+  {
+   "id": "node/6939882553",
+   "name": "A1 Pizza & Mini Mart",
+   "address": "602 North 6th Street, Allentown",
+   "lat": 40.6110984,
+   "lng": -75.4739633,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6939882553"
+  },
+  {
+   "id": "node/6311987074",
+   "name": "A1 Steak House II",
+   "address": "3219 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6570472,
+   "lng": -75.4183963,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6311987074"
+  },
+  {
+   "id": "way/1157359176",
+   "name": "Aci Halal",
+   "address": "34 North 2nd Street, Allentown",
+   "lat": 40.6065213,
+   "lng": -75.4607909,
+   "types": [
+    "restaurant",
+    "turkish"
+   ],
+   "cuisine": [
+    "turkish"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1157359176"
+  },
+  {
+   "id": "way/619185731",
+   "name": "AD’S kitchen",
+   "address": "",
+   "lat": 40.5103612,
+   "lng": -75.3911729,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14848639100",
+   "website": "https://www.facebook.com/people/ADs-Kitchen/100083267142510/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/619185731"
+  },
+  {
+   "id": "node/6337896519",
+   "name": "Adagio",
+   "address": "530 Pembroke Road, Bethlehem, PA",
+   "lat": 40.6266286,
+   "lng": -75.365663,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6337896519"
+  },
+  {
+   "id": "node/13022129334",
+   "name": "Affey's Sports Bar & Grill",
+   "address": "1202 Liberty Street, Allentown, PA",
+   "lat": 40.6058342,
+   "lng": -75.4855628,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022129334"
+  },
+  {
+   "id": "way/370374613",
+   "name": "Aladdin",
+   "address": "651 Union Boulevard, Allentown, PA",
+   "lat": 40.6242511,
+   "lng": -75.4491303,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "http://aladinlv.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/370374613"
+  },
+  {
+   "id": "node/9870432202",
+   "name": "Alburtis Fire Co.",
+   "address": "",
+   "lat": 40.5088331,
+   "lng": -75.6023254,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9870432202"
+  },
+  {
+   "id": "way/1305429084",
+   "name": "Alburtis Tavern",
+   "address": "106 South Main Street, Alburtis, PA",
+   "lat": 40.5113375,
+   "lng": -75.604055,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109280404",
+   "website": "https://alburtistavern.com/",
+   "openingHours": "Su-Th 11:00-21:00; Fr-Sa 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1305429084"
+  },
+  {
+   "id": "node/6157380986",
+   "name": "Alexandra's Bistro",
+   "address": "9 East 4th Street",
+   "lat": 40.6105701,
+   "lng": -75.3778605,
+   "types": [
+    "restaurant",
+    "burger",
+    "diner",
+    "american",
+    "breakfast",
+    "coffee_shop"
+   ],
+   "cuisine": [
+    "burger",
+    "diner",
+    "american",
+    "breakfast",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "Mo-Su 07:00-16:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6157380986"
+  },
+  {
+   "id": "node/12683556836",
+   "name": "Alibi Bar & Lounge",
+   "address": "203 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6121413,
+   "lng": -75.3757265,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12683556836"
+  },
+  {
+   "id": "way/77472380",
+   "name": "Alliance Hotel",
+   "address": "2332",
+   "lat": 40.6951858,
+   "lng": -75.4997345,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/77472380"
+  },
+  {
+   "id": "node/2281462435",
+   "name": "American Sandwich Co.",
+   "address": "",
+   "lat": 40.5180548,
+   "lng": -75.3872314,
+   "types": [
+    "restaurant",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "http://www.americansandwichco.com",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2281462435"
+  },
+  {
+   "id": "node/13759064055",
+   "name": "Amigos Mexican Grill",
+   "address": "932 Hamilton Street, Allentown, PA",
+   "lat": 40.6006228,
+   "lng": -75.4768936,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13759064055"
+  },
+  {
+   "id": "node/2410532660",
+   "name": "Amore Pizza",
+   "address": "",
+   "lat": 40.5789381,
+   "lng": -75.5309288,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/amore-pizza",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2410532660"
+  },
+  {
+   "id": "node/6314874444",
+   "name": "Anatolian Kitchen",
+   "address": "3016 Linden Street, Bethlehem, PA",
+   "lat": 40.6570133,
+   "lng": -75.3550304,
+   "types": [
+    "restaurant",
+    "turkish"
+   ],
+   "cuisine": [
+    "turkish"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6314874444"
+  },
+  {
+   "id": "way/43000780",
+   "name": "Anna's Brick Oven Pizza",
+   "address": "313 South New Street, Bethlehem, PA",
+   "lat": 40.6115597,
+   "lng": -75.3782697,
+   "types": [
+    "restaurant",
+    "italian",
+    "takeaway",
+    "delivery",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 317 0400",
+   "website": "https://www.salsbrickovenpizzamenu.com/",
+   "openingHours": "Mo-Th 11:00-22:00; Fr-Sa 11:00-23:00; Su 12:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/43000780"
+  },
+  {
+   "id": "node/5821469646",
+   "name": "Anthony's Coal Fired Pizza",
+   "address": "",
+   "lat": 40.5644823,
+   "lng": -75.5652343,
+   "types": [
+    "restaurant",
+    "pizza",
+    "wings"
+   ],
+   "cuisine": [
+    "pizza",
+    "wings"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Anthony's Coal Fired Pizza",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469646"
+  },
+  {
+   "id": "node/831649279",
+   "name": "Apollo Grill",
+   "address": "85 West Broad Street, Bethlehem, PA",
+   "lat": 40.6221948,
+   "lng": -75.3812747,
+   "types": [
+    "restaurant",
+    "mediterranean"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-865-9600",
+   "website": "https://www.apollogrill.com/",
+   "openingHours": "Tu-Sa 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649279"
+  },
+  {
+   "id": "way/53827526",
+   "name": "Applebee's",
+   "address": "1510 North Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.6123365,
+   "lng": -75.5335955,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-530-2450",
+   "website": "https://restaurants.applebees.com/en-us/pa/allentown/1510-n-cedar-crest-blvd-97059",
+   "openingHours": null,
+   "brand": "Applebee's Neighborhood Grill & Bar",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/53827526"
+  },
+  {
+   "id": "way/204137456",
+   "name": "Applebee's",
+   "address": "3730 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6727787,
+   "lng": -75.3452596,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-868-8569",
+   "website": "https://restaurants.applebees.com/en-us/pa/bethlehem/3730-nazareth-pike-75031",
+   "openingHours": null,
+   "brand": "Applebee's Neighborhood Grill & Bar",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/204137456"
+  },
+  {
+   "id": "way/472712107",
+   "name": "Applebee's",
+   "address": "7150 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5508573,
+   "lng": -75.5949671,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-366-8200",
+   "website": "https://restaurants.applebees.com/en-us/pa/trexlertown/7150-hamilton-blvd.-96020",
+   "openingHours": "Mo-Th,Su 11:30-23:00; Fr-Sa 11:30-24:00",
+   "brand": "Applebee's Neighborhood Grill & Bar",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/472712107"
+  },
+  {
+   "id": "way/1247048003",
+   "name": "Applebee's",
+   "address": "2109 Motel Drive, Bethlehem, PA",
+   "lat": 40.643795,
+   "lng": -75.4285821,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-867-7332",
+   "website": "https://restaurants.applebees.com/en-us/pa/bethlehem/2109-motel-drive-94087",
+   "openingHours": null,
+   "brand": "Applebee's Neighborhood Grill & Bar",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1247048003"
+  },
+  {
+   "id": "node/6338848539",
+   "name": "Aqui Es",
+   "address": "821 Linden Street, Bethlehem, PA",
+   "lat": 40.6256424,
+   "lng": -75.3706241,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338848539"
+  },
+  {
+   "id": "node/6904305363",
+   "name": "Arabian Mediterranean Food",
+   "address": "",
+   "lat": 40.6256581,
+   "lng": -75.4308172,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904305363"
+  },
+  {
+   "id": "way/79291003",
+   "name": "Arby's",
+   "address": "1229 Schadt Avenue, Whitehall, PA",
+   "lat": 40.642978,
+   "lng": -75.4881767,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-435-3019",
+   "website": "https://www.arbys.com/locations/us/pa/whitehall/1229-schadt-ave/store-7605/",
+   "openingHours": "10:00-22:00",
+   "brand": "Arby's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/79291003"
+  },
+  {
+   "id": "way/278761371",
+   "name": "Arby's",
+   "address": "1535 Lehigh Street, Allentown, PA",
+   "lat": 40.5787404,
+   "lng": -75.4800879,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-797-2034",
+   "website": "https://www.arbys.com/locations/us/pa/allentown/1535-lehigh-st/store-1093/",
+   "openingHours": "10:00-22:00",
+   "brand": "Arby's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278761371"
+  },
+  {
+   "id": "way/1193453164",
+   "name": "Arby's",
+   "address": "7720 Main Street, Fogelsville, PA",
+   "lat": 40.5838538,
+   "lng": -75.6270315,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-8966",
+   "website": "https://www.arbys.com/locations/us/pa/fogelsville/7720-main-st/store-6268/",
+   "openingHours": "10:00-22:00",
+   "brand": "Arby's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1193453164"
+  },
+  {
+   "id": "way/1278087224",
+   "name": "Arby's",
+   "address": "1305 Airport Road, Allentown, PA",
+   "lat": 40.6305268,
+   "lng": -75.4410794,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16104392330",
+   "website": "https://www.arbys.com/locations/us/pa/allentown/1305-airport-rd/store-7358/",
+   "openingHours": "10:00-22:00",
+   "brand": "Arby's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278087224"
+  },
+  {
+   "id": "way/1302652367",
+   "name": "Armando's Express Pizza",
+   "address": "1065 MacArthur Road, Whitehall, PA",
+   "lat": 40.6187246,
+   "lng": -75.4791464,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16104337600",
+   "website": "https://armandosexpresspizza.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1302652367"
+  },
+  {
+   "id": "way/1366157047",
+   "name": "Armetta's Italian Restaurant & Pub",
+   "address": "301 Main Street, Emmaus, PA",
+   "lat": 40.5360106,
+   "lng": -75.4905028,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109673050",
+   "website": "https://www.armettaspizzarestpub.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1366157047"
+  },
+  {
+   "id": "way/554002084",
+   "name": "Artisan Wine and Cheese Cellars",
+   "address": "55 West Lehigh Street, Bethlehem, PA",
+   "lat": 40.6167683,
+   "lng": -75.3822356,
+   "types": [
+    "bar",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 813 2851",
+   "website": "https://www.artisanwineandcheesecellars.com",
+   "openingHours": "We-Th 17:00-22:00; Fr-Sa 17:00-23:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/554002084"
+  },
+  {
+   "id": "way/1417082544",
+   "name": "Asia",
+   "address": "1102 East Susquehanna Street, Allentown, PA",
+   "lat": 40.5924205,
+   "lng": -75.4303856,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107987777",
+   "website": "https://www.asiaorientalcuisine.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1417082544"
+  },
+  {
+   "id": "way/1272778975",
+   "name": "Asian Bistros",
+   "address": "7441 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5499579,
+   "lng": -75.6014457,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16105300888",
+   "website": "https://www.asianbistrospa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1272778975"
+  },
+  {
+   "id": "node/11892215607",
+   "name": "Asian Dynasty",
+   "address": "",
+   "lat": 40.6305188,
+   "lng": -75.4802863,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11892215607"
+  },
+  {
+   "id": "node/13022264215",
+   "name": "Asian Taste Indo",
+   "address": "1201 West Linden Street, Allentown, PA",
+   "lat": 40.6009621,
+   "lng": -75.4826003,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022264215"
+  },
+  {
+   "id": "node/259499262",
+   "name": "Assante",
+   "address": "2050",
+   "lat": 40.6904677,
+   "lng": -75.4994807,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/259499262"
+  },
+  {
+   "id": "node/9113862380",
+   "name": "Auntie Anne's",
+   "address": "",
+   "lat": 40.5596852,
+   "lng": -75.4103103,
+   "types": [
+    "fast_food",
+    "pretzel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pretzel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16108410770",
+   "website": "https://auntieannes.com/",
+   "openingHours": "Mo-Sa 10:00-21:00",
+   "brand": "Auntie Anne's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9113862380"
+  },
+  {
+   "id": "node/12714766433",
+   "name": "Auntie Anne's",
+   "address": "4606 Broadway, Allentown, PA",
+   "lat": 40.5859762,
+   "lng": -75.5587535,
+   "types": [
+    "fast_food",
+    "pretzel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pretzel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Auntie Anne's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12714766433"
+  },
+  {
+   "id": "node/13019488589",
+   "name": "Auntie Anne's",
+   "address": "Allentown Service Plaza",
+   "lat": 40.5743285,
+   "lng": -75.5576543,
+   "types": [
+    "fast_food",
+    "pretzel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pretzel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Auntie Anne's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019488589"
+  },
+  {
+   "id": "way/860872718",
+   "name": "Auntie Anne's",
+   "address": "",
+   "lat": 40.57906,
+   "lng": -75.5325511,
+   "types": [
+    "fast_food",
+    "pretzel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pretzel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/auntie-annes",
+   "openingHours": null,
+   "brand": "Auntie Anne's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860872718"
+  },
+  {
+   "id": "node/7928570052",
+   "name": "Bamboo Asian Cuisine & Sushi Bar",
+   "address": "345 South Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.5831501,
+   "lng": -75.5208856,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928570052"
+  },
+  {
+   "id": "node/13025819357",
+   "name": "Bananas & Casa Java",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145427,
+   "lng": -75.3583001,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819357"
+  },
+  {
+   "id": "node/12714845633",
+   "name": "Bang Bang Hibachi - Trexlertown",
+   "address": "6900 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.550093,
+   "lng": -75.5911968,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12714845633"
+  },
+  {
+   "id": "node/11684849343",
+   "name": "Bang Bang Hibachi Grill & Sushi",
+   "address": "1519 Lehigh Street, Allentown, PA",
+   "lat": 40.5794729,
+   "lng": -75.479483,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11684849343"
+  },
+  {
+   "id": "node/2855712291",
+   "name": "Bar",
+   "address": "",
+   "lat": 40.4755025,
+   "lng": -75.6257993,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2855712291"
+  },
+  {
+   "id": "node/5678995193",
+   "name": "Bar Louie",
+   "address": "",
+   "lat": 40.5590762,
+   "lng": -75.41089,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Bar Louie",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5678995193"
+  },
+  {
+   "id": "node/6150116623",
+   "name": "Barbecue Boys",
+   "address": "306 South New Street, Bethlehem, PA",
+   "lat": 40.6114806,
+   "lng": -75.3786686,
+   "types": [
+    "restaurant",
+    "barbecue"
+   ],
+   "cuisine": [
+    "barbecue"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6150116623"
+  },
+  {
+   "id": "node/13019488591",
+   "name": "Baskin-Robbins",
+   "address": "Allentown Service Plaza",
+   "lat": 40.5742904,
+   "lng": -75.5579331,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Baskin-Robbins",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019488591"
+  },
+  {
+   "id": "way/1302626558",
+   "name": "Batch Microcreamery",
+   "address": "1160 Club House Lane, Allentown, PA",
+   "lat": 40.556614,
+   "lng": -75.5681765,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://batchmicrocreamery.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1302626558"
+  },
+  {
+   "id": "node/6338848532",
+   "name": "Bed Head Vegan Brunch House",
+   "address": "310 East Goepp Street, Bethlehem, PA",
+   "lat": 40.6259404,
+   "lng": -75.3699787,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [
+    "vegan"
+   ],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338848532"
+  },
+  {
+   "id": "node/6307335754",
+   "name": "Beef Baron",
+   "address": "2366 Catasauqua Road, Bethlehem, PA",
+   "lat": 40.6431601,
+   "lng": -75.4263297,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6307335754"
+  },
+  {
+   "id": "node/10621554350",
+   "name": "Beer Mussels",
+   "address": "1214 Main Street, Hellertown, PA",
+   "lat": 40.5871009,
+   "lng": -75.3415011,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108388200",
+   "website": null,
+   "openingHours": "16:00-02:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10621554350"
+  },
+  {
+   "id": "node/6139345107",
+   "name": "Bell Hall",
+   "address": "612 West Hamilton Street, Allentown, PA",
+   "lat": 40.6024568,
+   "lng": -75.4701317,
+   "types": [
+    "restaurant",
+    "bar_and_grill"
+   ],
+   "cuisine": [
+    "bar_and_grill"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6139345107"
+  },
+  {
+   "id": "way/1368608319",
+   "name": "Bella Pizza II",
+   "address": "578 Chestnut Street, Emmaus, PA",
+   "lat": 40.5331489,
+   "lng": -75.4956153,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109661080",
+   "website": "https://bellapizzaemmaus.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1368608319"
+  },
+  {
+   "id": "node/3766570509",
+   "name": "Bella's Ristorante",
+   "address": "639 Main Street, Hellertown, PA",
+   "lat": 40.5787404,
+   "lng": -75.3406073,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3766570509"
+  },
+  {
+   "id": "node/12692225877",
+   "name": "Benny's Cafe",
+   "address": "3690 Lehigh Street, Whitehall, PA",
+   "lat": 40.6551956,
+   "lng": -75.4960475,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12692225877"
+  },
+  {
+   "id": "node/9870510768",
+   "name": "Berlinsville Hotel",
+   "address": "4588 Lehigh Drive, Walnutport, PA",
+   "lat": 40.7680106,
+   "lng": -75.5707617,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9870510768"
+  },
+  {
+   "id": "way/1420279391",
+   "name": "Best Station Hotel",
+   "address": "4425 Best Station Road, Slatington, PA",
+   "lat": 40.7249175,
+   "lng": -75.6541526,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107671370",
+   "website": "https://www.beststationhotel.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1420279391"
+  },
+  {
+   "id": "node/13025819329",
+   "name": "Bethlehem Barrel and Drafthouse",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6144713,
+   "lng": -75.3595306,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819329"
+  },
+  {
+   "id": "node/993736322",
+   "name": "Bethlehem Dairy Store",
+   "address": "1430 Linden Street, Bethlehem, PA",
+   "lat": 40.6330812,
+   "lng": -75.3690368,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/993736322"
+  },
+  {
+   "id": "way/51552686",
+   "name": "Bethlehem Diner",
+   "address": "1871 Catasauqua Road, Allentown, PA",
+   "lat": 40.6414154,
+   "lng": -75.4311627,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/51552686"
+  },
+  {
+   "id": "node/7928986830",
+   "name": "Biaggio Pizza Restaraunt",
+   "address": "1526 North Cedar Crest Boulevard, Allentown",
+   "lat": 40.6120792,
+   "lng": -75.5352091,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://biaggiopizza.com/",
+   "openingHours": "Mo-Th 10:00-20:30; Fr,Sa 10:00-21:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928986830"
+  },
+  {
+   "id": "node/6907398987",
+   "name": "Big Woody's",
+   "address": "1302 Hanover Avenue, Allentown, PA",
+   "lat": 40.6180338,
+   "lng": -75.4335458,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://bigwoodysrestaurant.com/",
+   "openingHours": "Mo-Su 11:00-02:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907398987"
+  },
+  {
+   "id": "node/13033482083",
+   "name": "Big Woody's",
+   "address": "1928 Hamilton Street, Allentown, PA",
+   "lat": 40.5942726,
+   "lng": -75.4977813,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033482083"
+  },
+  {
+   "id": "way/278756639",
+   "name": "Big Woody's Sports Bar & Grill",
+   "address": "",
+   "lat": 40.522037,
+   "lng": -75.5186418,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278756639"
+  },
+  {
+   "id": "node/2740433915",
+   "name": "Big Woody's Sports Bar and Grill",
+   "address": "2625 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6458204,
+   "lng": -75.3461871,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2740433915"
+  },
+  {
+   "id": "node/831824189",
+   "name": "Billy's Downtown Diner",
+   "address": "10 East Broad Street, Bethlehem, PA",
+   "lat": 40.6221901,
+   "lng": -75.3780475,
+   "types": [
+    "restaurant",
+    "diner"
+   ],
+   "cuisine": [
+    "diner"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-867-0105",
+   "website": "https://www.billysdiner.com/",
+   "openingHours": "07:00-15:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831824189"
+  },
+  {
+   "id": "node/5856774223",
+   "name": "Binnies Hot Dogs & Family Restaurant",
+   "address": "101 North Front Street, Coplay, PA",
+   "lat": 40.6749501,
+   "lng": -75.4917513,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5856774223"
+  },
+  {
+   "id": "node/5876415698",
+   "name": "Biryani City Allentown",
+   "address": "1894 Catasauqua Road, Allentown, PA",
+   "lat": 40.6403879,
+   "lng": -75.4292855,
+   "types": [
+    "restaurant",
+    "indian"
+   ],
+   "cuisine": [
+    "indian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5876415698"
+  },
+  {
+   "id": "node/9230913541",
+   "name": "Bitty & Beau's Coffee",
+   "address": "74 West Broad Street, Bethlehem, PA",
+   "lat": 40.6225918,
+   "lng": -75.3817715,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484 225 8358",
+   "website": "https://www.bittyandbeauscoffee.com/location/bethlehem/",
+   "openingHours": "Mo-Su 08:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9230913541"
+  },
+  {
+   "id": "way/576112470",
+   "name": "BJ's",
+   "address": "665 North Krocks Road, Allentown, PA",
+   "lat": 40.5654833,
+   "lng": -75.563756,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-268-2340",
+   "website": "https://www.bjsrestaurants.com/locations/pa/allentown",
+   "openingHours": null,
+   "brand": "BJ's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/576112470"
+  },
+  {
+   "id": "node/11803492128",
+   "name": "Blocker's Coffeehouse",
+   "address": "309 Front Street, Catasauqua, PA",
+   "lat": 40.6520278,
+   "lng": -75.472303,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-443-0707",
+   "website": "https://www.blockerscoffee.com/",
+   "openingHours": "Mo-Fr 06:00-15:30; Sa-Su 07:00-14:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11803492128"
+  },
+  {
+   "id": "way/350451684",
+   "name": "Blue Grillhouse",
+   "address": "",
+   "lat": 40.6669998,
+   "lng": -75.3089917,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/350451684"
+  },
+  {
+   "id": "node/3250349891",
+   "name": "Bolete",
+   "address": "1740 Seidersville Road, Bethlehem, PA",
+   "lat": 40.5946899,
+   "lng": -75.4117868,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 868-6505",
+   "website": "https://www.boleterestaurant.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3250349891"
+  },
+  {
+   "id": "node/5800087425",
+   "name": "Bonefish Grill",
+   "address": "",
+   "lat": 40.6293869,
+   "lng": -75.4821547,
+   "types": [
+    "restaurant",
+    "seafood"
+   ],
+   "cuisine": [
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Bonefish Grill",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087425"
+  },
+  {
+   "id": "node/12151617896",
+   "name": "Borderline Restaurant",
+   "address": "2100 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6285196,
+   "lng": -75.4169671,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12151617896"
+  },
+  {
+   "id": "node/2768560503",
+   "name": "Bracco's pizza, steak, and subs",
+   "address": "",
+   "lat": 40.7085676,
+   "lng": -75.3944566,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2768560503"
+  },
+  {
+   "id": "way/346387166",
+   "name": "Braveheart Highland Pub",
+   "address": "430 Main Street, Hellertown, PA",
+   "lat": 40.5771128,
+   "lng": -75.340933,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/346387166"
+  },
+  {
+   "id": "way/504486476",
+   "name": "Braza & Candela",
+   "address": "1756 South 4th Street, Allentown, PA",
+   "lat": 40.5827226,
+   "lng": -75.4579623,
+   "types": [
+    "restaurant",
+    "chicken"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/504486476"
+  },
+  {
+   "id": "way/618282460",
+   "name": "Brick Tavern Inn",
+   "address": "2460 North Old Bethlehem Pike, Quakertown, PA",
+   "lat": 40.4583703,
+   "lng": -75.3853369,
+   "types": [
+    "restaurant",
+    "takeaway"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 215-529-6488",
+   "website": "https://www.thebricktaverninn.com/",
+   "openingHours": "We-Sa 12:00-21:00; Su 12:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/618282460"
+  },
+  {
+   "id": "node/4317500114",
+   "name": "Broad Street Pizza",
+   "address": "516 West Broad Street, Bethlehem, PA",
+   "lat": 40.6226079,
+   "lng": -75.3903669,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4317500114"
+  },
+  {
+   "id": "way/1511984770",
+   "name": "Bru Daddy's Brewing Co.",
+   "address": "732 Hamilton Street, Allentown, PA",
+   "lat": 40.6014662,
+   "lng": -75.4728386,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-351-7600",
+   "website": "https://www.brudaddysbrewingcompany.com/",
+   "openingHours": "Mo-Th 11:00-23:00; Fr,Sa 11:00-00:00; Su 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1511984770"
+  },
+  {
+   "id": "way/350451680",
+   "name": "Bruno Scipioni's Italian Ristorante & Pizzeria",
+   "address": "",
+   "lat": 40.6639749,
+   "lng": -75.3196281,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/350451680"
+  },
+  {
+   "id": "way/351727027",
+   "name": "Bubba's Potbelly Stove Restaurant",
+   "address": "1485",
+   "lat": 40.4854227,
+   "lng": -75.377365,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/351727027"
+  },
+  {
+   "id": "way/278756656",
+   "name": "Buckeye Tavern",
+   "address": "3741 Brookside Road, Macungie, PA",
+   "lat": 40.5189568,
+   "lng": -75.5449607,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109664411",
+   "website": "https://www.buckeyetavern.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278756656"
+  },
+  {
+   "id": "way/531604518",
+   "name": "Buffalo Wild Wings",
+   "address": "1225 Grape Street, Whitehall, PA",
+   "lat": 40.6335338,
+   "lng": -75.4825125,
+   "types": [
+    "restaurant",
+    "wings"
+   ],
+   "cuisine": [
+    "wings"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102660527",
+   "website": "https://www.buffalowildwings.com/locations/us/pa/whitehall/1225-grape-st/sports-bar-1106/",
+   "openingHours": null,
+   "brand": "Buffalo Wild Wings",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531604518"
+  },
+  {
+   "id": "node/6219840092",
+   "name": "Buona Cucina",
+   "address": "1519 Irene Street, Bethlehem, PA",
+   "lat": 40.6400116,
+   "lng": -75.3468171,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6219840092"
+  },
+  {
+   "id": "way/232833658",
+   "name": "Burger Barn",
+   "address": "",
+   "lat": 40.5801532,
+   "lng": -75.5341306,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/burger-barn",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232833658"
+  },
+  {
+   "id": "node/5807665760",
+   "name": "Burger King",
+   "address": "3105 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.652396,
+   "lng": -75.414084,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1097",
+   "website": "https://www.bk.com/store-locator/store/restaurant_4600",
+   "openingHours": "Mo-Sa 06:00-22:00; Su 07:00-21:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665760"
+  },
+  {
+   "id": "node/11978290025",
+   "name": "Burger King",
+   "address": "3924 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6737486,
+   "lng": -75.3445839,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11978290025"
+  },
+  {
+   "id": "way/79290984",
+   "name": "Burger King",
+   "address": "2687 MacArthur Road, Whitehall, PA",
+   "lat": 40.6462361,
+   "lng": -75.4935419,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1093",
+   "website": "https://www.bk.com/store-locator/store/restaurant_5170",
+   "openingHours": "Mo-Sa 06:00-22:00; Su 07:00-22:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/79290984"
+  },
+  {
+   "id": "way/154238309",
+   "name": "Burger King",
+   "address": "1600 MacArthur Road, Whitehall, PA",
+   "lat": 40.6292942,
+   "lng": -75.4849586,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1092",
+   "website": "https://www.bk.com/store-locator/store/restaurant_165",
+   "openingHours": "07:00-22:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/154238309"
+  },
+  {
+   "id": "way/198872824",
+   "name": "Burger King",
+   "address": "2141 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6433573,
+   "lng": -75.3464898,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1096",
+   "website": "https://www.bk.com/store-locator/store/restaurant_172",
+   "openingHours": "Mo-Sa 06:00-22:00; Su 07:00-21:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872824"
+  },
+  {
+   "id": "way/348449422",
+   "name": "Burger King",
+   "address": "2165 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6260748,
+   "lng": -75.4189626,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1099",
+   "website": "https://www.bk.com/store-locator/store/restaurant_218",
+   "openingHours": "06:00-22:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/348449422"
+  },
+  {
+   "id": "way/473387119",
+   "name": "Burger King",
+   "address": "1116 Chestnut Street, Emmaus, PA",
+   "lat": 40.5283915,
+   "lng": -75.5060905,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-742-2080",
+   "website": "https://www.bk.com/store-locator/store/restaurant_237822",
+   "openingHours": "06:00-22:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/473387119"
+  },
+  {
+   "id": "way/504487709",
+   "name": "Burger King",
+   "address": "1958 South 4th Street, Allentown, PA",
+   "lat": 40.5782213,
+   "lng": -75.4551134,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1095",
+   "website": "https://www.bk.com/store-locator/store/restaurant_247",
+   "openingHours": "Mo-Sa 05:30-22:00; Su 07:00-21:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/504487709"
+  },
+  {
+   "id": "way/594653176",
+   "name": "Burger King",
+   "address": "201 South Best Avenue, Walnutport, PA",
+   "lat": 40.7569975,
+   "lng": -75.5932022,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-224-9000",
+   "website": "https://www.bk.com/store-locator/store/restaurant_1346",
+   "openingHours": "Mo-Sa 06:00-21:00; Su 07:00-21:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/594653176"
+  },
+  {
+   "id": "way/642048542",
+   "name": "Burger King",
+   "address": "2575 PA 309, Orefield, PA",
+   "lat": 40.6280227,
+   "lng": -75.5818239,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-336-8980",
+   "website": "https://www.bk.com/store-locator/store/restaurant_7335",
+   "openingHours": "Mo-Sa 06:00-21:00; Su 07:00-21:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/642048542"
+  },
+  {
+   "id": "way/728255620",
+   "name": "Burger King",
+   "address": "7712 Adrienne Drive, Breinigsville, PA",
+   "lat": 40.5769066,
+   "lng": -75.6228038,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-426-1091",
+   "website": "https://www.bk.com/store-locator/store/restaurant_3000",
+   "openingHours": "Mo-Sa 06:00-22:00; Su 07:00-21:00",
+   "brand": "Burger King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/728255620"
+  },
+  {
+   "id": "way/1436552518",
+   "name": "Burrito Nacho Mexican Grill",
+   "address": "1507 South 4th Street, Allentown, PA",
+   "lat": 40.585742,
+   "lng": -75.4594115,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107099992",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1436552518"
+  },
+  {
+   "id": "node/4886201641",
+   "name": "Cachette Bistro & Creperie",
+   "address": "504 Main Street, Bethlehem, PA",
+   "lat": 40.6208262,
+   "lng": -75.3818571,
+   "types": [
+    "restaurant",
+    "french",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "french"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-625-2515",
+   "website": "https://cachettebethlehem.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4886201641"
+  },
+  {
+   "id": "node/12683558884",
+   "name": "Cafe Crewy",
+   "address": "21 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6121075,
+   "lng": -75.3776073,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12683558884"
+  },
+  {
+   "id": "node/3766570510",
+   "name": "Cafe Erica",
+   "address": "637 Main Street, Hellertown, PA",
+   "lat": 40.5786487,
+   "lng": -75.34061,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3766570510"
+  },
+  {
+   "id": "node/6590078699",
+   "name": "Cafe Phuong",
+   "address": "725 North 4th Street, Allentown, PA",
+   "lat": 40.6145068,
+   "lng": -75.4702444,
+   "types": [
+    "restaurant",
+    "vietnamese"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6590078699"
+  },
+  {
+   "id": "node/6215093535",
+   "name": "Cafe The Lodge",
+   "address": "427 East 4th Street, Bethlehem, PA",
+   "lat": 40.6107362,
+   "lng": -75.372237,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6215093535"
+  },
+  {
+   "id": "way/778019248",
+   "name": "Cali Burrito",
+   "address": "2149 Reading Road, Allentown, PA",
+   "lat": 40.5929824,
+   "lng": -75.5020981,
+   "types": [
+    "restaurant",
+    "tex-mex"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103511791",
+   "website": "https://www.caliburrito.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/778019248"
+  },
+  {
+   "id": "node/708868637",
+   "name": "Campus Pizza",
+   "address": "22 East 4th Street, Bethlehem, PA",
+   "lat": 40.6103316,
+   "lng": -75.3777243,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/708868637"
+  },
+  {
+   "id": "node/13127916362",
+   "name": "Capriotti's",
+   "address": "5585 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5615184,
+   "lng": -75.5660724,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Capriotti's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13127916362"
+  },
+  {
+   "id": "node/904053577",
+   "name": "Carl's Corner",
+   "address": "2 W Elizabeth Ave, Bethlehem",
+   "lat": 40.6311504,
+   "lng": -75.3782849,
+   "types": [
+    "restaurant",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/904053577"
+  },
+  {
+   "id": "node/2622791397",
+   "name": "Carlo's Pizza",
+   "address": "7001 North Route 309, Coopersburg, PA",
+   "lat": 40.5179235,
+   "lng": -75.3876457,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-282-4480",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2622791397"
+  },
+  {
+   "id": "way/53637204",
+   "name": "Carrabba's Italian Grill",
+   "address": "510 South Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.58074,
+   "lng": -75.5229133,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Carrabba's Italian Grill",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/53637204"
+  },
+  {
+   "id": "node/6307335755",
+   "name": "Carvel",
+   "address": "2364 Catasauqua Road, Bethlehem, PA",
+   "lat": 40.643098,
+   "lng": -75.426329,
+   "types": [
+    "ice_cream",
+    "takeaway"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Carvel",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6307335755"
+  },
+  {
+   "id": "way/1369420968",
+   "name": "Casa De Campo Restaurante",
+   "address": "123 West 4th Street, Bethlehem, PA",
+   "lat": 40.6105593,
+   "lng": -75.3807444,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1369420968"
+  },
+  {
+   "id": "node/831649248",
+   "name": "Casa del Mofongo",
+   "address": "553 Main Street, Bethlehem, PA",
+   "lat": 40.6217933,
+   "lng": -75.3821681,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649248"
+  },
+  {
+   "id": "node/11163392717",
+   "name": "Casa del San-Gwich",
+   "address": "20 West Broad Street, Bethlehem, PA",
+   "lat": 40.6224465,
+   "lng": -75.3791224,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484 896 9330",
+   "website": "https://order.toasttab.com/online/casa-del-san-gwich-20-w-broad-street",
+   "openingHours": "Su 10:00-16:45; Tu-Fr 09:00-16:45; Sa 10:00-17:45",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11163392717"
+  },
+  {
+   "id": "node/6943158022",
+   "name": "Casa Latina",
+   "address": "527 North 7th Street, Allentown, PA",
+   "lat": 40.6099612,
+   "lng": -75.4751919,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158022"
+  },
+  {
+   "id": "node/5785275739",
+   "name": "Casa Mia Pizzeria",
+   "address": "3711 PA 378, Bethlehem, PA",
+   "lat": 40.5866376,
+   "lng": -75.3846169,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5785275739"
+  },
+  {
+   "id": "node/5408399950",
+   "name": "Casa Toro",
+   "address": "7001 N Route 309, Coopersburg, PA",
+   "lat": 40.5178856,
+   "lng": -75.3878511,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "Mo-Su 10:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5408399950"
+  },
+  {
+   "id": "node/7314134204",
+   "name": "Casey's Place",
+   "address": "1197 California Road",
+   "lat": 40.4755086,
+   "lng": -75.3475799,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7314134204"
+  },
+  {
+   "id": "node/5762218325",
+   "name": "Castle Diner & Family Restaurant",
+   "address": "",
+   "lat": 40.4714797,
+   "lng": -75.3712348,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5762218325"
+  },
+  {
+   "id": "node/13033926689",
+   "name": "Catty Pizza",
+   "address": "501 2nd Street, Catasauqua, PA",
+   "lat": 40.6545664,
+   "lng": -75.4735248,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102662599",
+   "website": "https://www.cattypizzamenu.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033926689"
+  },
+  {
+   "id": "node/7937971900",
+   "name": "Cavaluzzo's",
+   "address": "1328 Chestnut Street, Emmaus, PA",
+   "lat": 40.5266147,
+   "lng": -75.5095673,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971900"
+  },
+  {
+   "id": "way/232833670",
+   "name": "Center Stage Fries",
+   "address": "",
+   "lat": 40.5799642,
+   "lng": -75.5344315,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/center-stage-fries",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232833670"
+  },
+  {
+   "id": "node/6935219408",
+   "name": "Chan's",
+   "address": "201 North 7th Street, Allentown",
+   "lat": 40.6052106,
+   "lng": -75.4729215,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6935219408"
+  },
+  {
+   "id": "node/5160169650",
+   "name": "Charles Pizza",
+   "address": "1190 Mickley Road, Whitehall, PA",
+   "lat": 40.6377653,
+   "lng": -75.4861624,
+   "types": [
+    "restaurant",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-434-0877",
+   "website": "https://www.charlespizzawhitehall.com",
+   "openingHours": "Tu-Th 11:00-21:00;Fr-Sa 11:00-22:00;Su 12:00-20:00;Mo off",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5160169650"
+  },
+  {
+   "id": "node/6212134071",
+   "name": "Charly's Thai",
+   "address": "832 East 4th Street, Bethlehem, PA",
+   "lat": 40.6106647,
+   "lng": -75.3662249,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6212134071"
+  },
+  {
+   "id": "node/6545606452",
+   "name": "Chef Panda",
+   "address": "",
+   "lat": 40.5519261,
+   "lng": -75.6076392,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6545606452"
+  },
+  {
+   "id": "node/5661523169",
+   "name": "Cherry's Caribbean Palace",
+   "address": "415 Main Street, Freemansburg, PA",
+   "lat": 40.6277242,
+   "lng": -75.335041,
+   "types": [
+    "restaurant",
+    "regional"
+   ],
+   "cuisine": [
+    "regional"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 4456",
+   "website": "https://www.cherryscaribbeanpalace.com/",
+   "openingHours": "Mo-Sa 11:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5661523169"
+  },
+  {
+   "id": "node/9870510769",
+   "name": "Cherryville Pizza & Pub",
+   "address": "4209 Lehigh Drive, Cherryville, PA",
+   "lat": 40.7542357,
+   "lng": -75.5397428,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9870510769"
+  },
+  {
+   "id": "node/6923619210",
+   "name": "Chicago Sports Bar & Grill",
+   "address": "1193 Airport Road, Allentown, PA",
+   "lat": 40.6284508,
+   "lng": -75.4396839,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6923619210"
+  },
+  {
+   "id": "node/4378216054",
+   "name": "Chick-fil-A",
+   "address": "826 Lehigh Lifestyle Center, Whitehall, PA",
+   "lat": 40.6303861,
+   "lng": -75.4803763,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-231-0303",
+   "website": "https://www.chick-fil-a.com/locations/pa/lehigh-valley-mall",
+   "openingHours": "Mo-Th 10:00-20:00; Fr-Sa 10:00-21:00; Su off",
+   "brand": "Chick-fil-A",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4378216054"
+  },
+  {
+   "id": "way/351891089",
+   "name": "Chick-fil-A",
+   "address": "602 North West End Boulevard, Quakertown, PA",
+   "lat": 40.4601347,
+   "lng": -75.3693659,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 215-538-8848",
+   "website": "https://www.chick-fil-a.com/locations/pa/quakertown",
+   "openingHours": "Mo-Sa 06:30-22:00; Su off",
+   "brand": "Chick-fil-A",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/351891089"
+  },
+  {
+   "id": "way/488270721",
+   "name": "Chick-fil-A",
+   "address": "6379 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5564772,
+   "lng": -75.580893,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 484-664-2907",
+   "website": "https://www.chick-fil-a.com/locations/pa/trexlertown",
+   "openingHours": "Mo-Sa 06:30-22:00; Su off",
+   "brand": "Chick-fil-A",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/488270721"
+  },
+  {
+   "id": "way/531124965",
+   "name": "Chick-fil-A",
+   "address": "261- MacArthur Road, Whitehall, PA",
+   "lat": 40.6446098,
+   "lng": -75.4931394,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-432-2307",
+   "website": "https://www.chick-fil-a.com/locations/pa/whitehall",
+   "openingHours": "Mo-Sa 06:30-22:00; Su off",
+   "brand": "Chick-fil-A",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531124965"
+  },
+  {
+   "id": "node/7928567583",
+   "name": "Chicken Lounge",
+   "address": "3247 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5793991,
+   "lng": -75.5245348,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928567583"
+  },
+  {
+   "id": "way/232726106",
+   "name": "Chicken Shack",
+   "address": "",
+   "lat": 40.5802991,
+   "lng": -75.5321645,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/chicken-shack",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232726106"
+  },
+  {
+   "id": "way/858690453",
+   "name": "Chickie's & Pete's",
+   "address": "",
+   "lat": 40.5789387,
+   "lng": -75.5338194,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/chickies-petes",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/858690453"
+  },
+  {
+   "id": "node/5851415241",
+   "name": "Chickie’s & Pete’s",
+   "address": "701 Hamilton Street, Allentown, PA",
+   "lat": 40.6020243,
+   "lng": -75.4728764,
+   "types": [
+    "restaurant",
+    "chicken"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-484-273-4507",
+   "website": "https://chickiesandpetes.com/location/allentown-2/",
+   "openingHours": "Tu-Fr 11:00-14:30; Sa,Su,Mo off",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5851415241"
+  },
+  {
+   "id": "way/232726129",
+   "name": "Chickie's and Pete's Sports Bar",
+   "address": "",
+   "lat": 40.5800618,
+   "lng": -75.531873,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/chickies-petes-sports-bar",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232726129"
+  },
+  {
+   "id": "way/94395428",
+   "name": "Chili's",
+   "address": "815 Grape Street, Whitehall, PA",
+   "lat": 40.6352086,
+   "lng": -75.4769351,
+   "types": [
+    "restaurant",
+    "tex-mex"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+16102644400",
+   "website": "https://www.chilis.com/locations/us/pennsylvania/whitehall/allentown",
+   "openingHours": null,
+   "brand": "Chili's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/94395428"
+  },
+  {
+   "id": "node/9401055491",
+   "name": "China House",
+   "address": "4783 Tilghman Street, Allentown, PA",
+   "lat": 40.5902775,
+   "lng": -75.5621663,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9401055491"
+  },
+  {
+   "id": "node/11684849345",
+   "name": "China House",
+   "address": "1527 Lehigh Street, Allentown, PA",
+   "lat": 40.5794136,
+   "lng": -75.4793618,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11684849345"
+  },
+  {
+   "id": "way/595629230",
+   "name": "China House II",
+   "address": "4515 PA 309, Schnecksville, PA",
+   "lat": 40.6667443,
+   "lng": -75.6060246,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107691888",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/595629230"
+  },
+  {
+   "id": "node/8210322223",
+   "name": "China Hut",
+   "address": "2415 MacArthur Road, Whitehall, PA",
+   "lat": 40.6425982,
+   "lng": -75.4902864,
+   "types": [
+    "fast_food",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-439-8888",
+   "website": "https://www.chinahutwhitehall.com/",
+   "openingHours": "Mo off; Tu-Th 11:00-22:00; Fr-Sa 11:00-23:00; Su 12:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8210322223"
+  },
+  {
+   "id": "node/13060097096",
+   "name": "China Inn",
+   "address": "619 Main Street, Slatington, PA",
+   "lat": 40.7513367,
+   "lng": -75.6127409,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14846234949",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13060097096"
+  },
+  {
+   "id": "node/7986136235",
+   "name": "China King",
+   "address": "",
+   "lat": 40.5581223,
+   "lng": -75.4835958,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7986136235"
+  },
+  {
+   "id": "node/9723503528",
+   "name": "China King",
+   "address": "3827 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6740219,
+   "lng": -75.3472208,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9723503528"
+  },
+  {
+   "id": "node/13033549307",
+   "name": "China King Allentown",
+   "address": "1901 Hamilton Street, Allentown, PA",
+   "lat": 40.5958197,
+   "lng": -75.4973416,
+   "types": [
+    "fast_food",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033549307"
+  },
+  {
+   "id": "node/5265691826",
+   "name": "China Moon",
+   "address": "",
+   "lat": 40.7305913,
+   "lng": -75.3174588,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5265691826"
+  },
+  {
+   "id": "node/6904094778",
+   "name": "China Moon",
+   "address": "2102 Union Boulevard, Allentown, PA",
+   "lat": 40.6256181,
+   "lng": -75.42353,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904094778"
+  },
+  {
+   "id": "node/11893016945",
+   "name": "China Moon",
+   "address": "7751 Glenlivet Drive West, Fogelsville, PA",
+   "lat": 40.5904723,
+   "lng": -75.6304649,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11893016945"
+  },
+  {
+   "id": "node/13030682110",
+   "name": "China Moon",
+   "address": "1842 Leithsville Road, Hellertown, PA",
+   "lat": 40.563717,
+   "lng": -75.340191,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13030682110"
+  },
+  {
+   "id": "node/6338848537",
+   "name": "China Star",
+   "address": "827 Linden Street, Bethlehem, PA",
+   "lat": 40.6258147,
+   "lng": -75.3706137,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338848537"
+  },
+  {
+   "id": "node/4393598192",
+   "name": "China Wok",
+   "address": "5040 PA 873, Schnecksville, PA",
+   "lat": 40.6780004,
+   "lng": -75.6153266,
+   "types": [
+    "fast_food",
+    "chinese",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "China Wok",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4393598192"
+  },
+  {
+   "id": "node/6943186661",
+   "name": "China Wok",
+   "address": "333 North 7th Street, Allentown, PA",
+   "lat": 40.6074061,
+   "lng": -75.4739824,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943186661"
+  },
+  {
+   "id": "node/13061246846",
+   "name": "China Wok",
+   "address": "2441 Emaus Avenue, Allentown, PA",
+   "lat": 40.5661581,
+   "lng": -75.4749088,
+   "types": [
+    "fast_food",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061246846"
+  },
+  {
+   "id": "node/4033114036",
+   "name": "Chipotle",
+   "address": "1870 Airport Road, Allentown, PA",
+   "lat": 40.6395903,
+   "lng": -75.4348848,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": 2,
+   "phone": "+1 484-353-1695",
+   "website": "https://locations.chipotle.com/pa/allentown/1870-airport-rd",
+   "openingHours": "Mo-Su 10:45-22:00",
+   "brand": "Chipotle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4033114036"
+  },
+  {
+   "id": "node/4378216053",
+   "name": "Chipotle",
+   "address": "837 Lehigh Lifestyle Center, Whitehall, PA",
+   "lat": 40.6300228,
+   "lng": -75.4802842,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": 2,
+   "phone": "+1 610-465-9526",
+   "website": "https://locations.chipotle.com/pa/whitehall/837-lehigh-lifestyle-ctr",
+   "openingHours": "Mo-Sa 10:45-22:00; Su 10:45-18:00",
+   "brand": "Chipotle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4378216053"
+  },
+  {
+   "id": "node/5785364823",
+   "name": "Chipotle",
+   "address": "750 North Krocks Road, Allentown, PA",
+   "lat": 40.5646851,
+   "lng": -75.5646259,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": 2,
+   "phone": "+1 610-336-8484",
+   "website": "https://locations.chipotle.com/pa/allentown/750-n-krocks-rd",
+   "openingHours": "Mo-Su 10:45-22:00",
+   "brand": "Chipotle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5785364823"
+  },
+  {
+   "id": "node/5821469623",
+   "name": "Chipotle",
+   "address": "3114 Tilghman Street, Allentown, PA",
+   "lat": 40.597108,
+   "lng": -75.5268713,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": 2,
+   "phone": "+1 610-437-3401",
+   "website": "https://locations.chipotle.com/pa/allentown/3114-w-tilghman-st",
+   "openingHours": "Mo-Su 10:45-22:00",
+   "brand": "Chipotle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469623"
+  },
+  {
+   "id": "node/5927886795",
+   "name": "Chipotle",
+   "address": "4743 Freemansburg Avenue, Easton, PA",
+   "lat": 40.6504772,
+   "lng": -75.2947783,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": 2,
+   "phone": "+1 610-691-1925",
+   "website": "https://locations.chipotle.com/pa/easton/4743-freemansburg-ave",
+   "openingHours": "Mo-Su 10:45-22:00",
+   "brand": "Chipotle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5927886795"
+  },
+  {
+   "id": "way/198872057",
+   "name": "Chipotle",
+   "address": "",
+   "lat": 40.6443951,
+   "lng": -75.3470697,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Chipotle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872057"
+  },
+  {
+   "id": "node/13025819359",
+   "name": "Chop House at Wind Creek",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6142752,
+   "lng": -75.3570642,
+   "types": [
+    "restaurant",
+    "steak_house"
+   ],
+   "cuisine": [
+    "steak_house"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819359"
+  },
+  {
+   "id": "node/9264383888",
+   "name": "Chopfin",
+   "address": "",
+   "lat": 40.6120505,
+   "lng": -75.5319045,
+   "types": [
+    "restaurant",
+    "poke"
+   ],
+   "cuisine": [
+    "poke"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.chopfin.com/",
+   "openingHours": "Mo-Sa 11:00-19:30; Su 11:00-16:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9264383888"
+  },
+  {
+   "id": "node/6907399007",
+   "name": "Chopsticks",
+   "address": "1314 Hanover Avenue, Allentown, PA",
+   "lat": 40.6179405,
+   "lng": -75.4347509,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907399007"
+  },
+  {
+   "id": "node/13025819361",
+   "name": "Chopsticks",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6151301,
+   "lng": -75.3569109,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819361"
+  },
+  {
+   "id": "node/7937971885",
+   "name": "Chopsticks Chinese Restaurant",
+   "address": "",
+   "lat": 40.5278916,
+   "lng": -75.5092505,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971885"
+  },
+  {
+   "id": "node/9832052223",
+   "name": "Chopstix Express",
+   "address": "2910 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6474422,
+   "lng": -75.3390381,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9832052223"
+  },
+  {
+   "id": "way/1354221311",
+   "name": "Chris & Eli Family Restaurant",
+   "address": "7115 PA 873, Slatington, PA",
+   "lat": 40.7324957,
+   "lng": -75.616968,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14842630222",
+   "website": "https://www.facebook.com/people/Chris-Eli-Family-Restaurant/100075516654652/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1354221311"
+  },
+  {
+   "id": "node/13000008611",
+   "name": "Chris' Family Restaurant",
+   "address": "5635 Tilghman St",
+   "lat": 40.5925458,
+   "lng": -75.5879056,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-395-9252",
+   "website": "https://chrissfamilyrestaurant.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13000008611"
+  },
+  {
+   "id": "way/93721968",
+   "name": "Chuck E. Cheese",
+   "address": "1000",
+   "lat": 40.6320867,
+   "lng": -75.4758351,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://locations.chuckecheese.com/us/pa/whitehall/1000-lehigh-valley-mall",
+   "openingHours": null,
+   "brand": "Chuck E. Cheese",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/93721968"
+  },
+  {
+   "id": "way/1375140880",
+   "name": "Chuck Wagon Drive-In",
+   "address": "4020 Mauch Chunk Road, Coplay, PA",
+   "lat": 40.6671135,
+   "lng": -75.5657716,
+   "types": [
+    "restaurant",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107990171",
+   "website": "https://www.facebook.com/people/Chuck-Wagon-Drive-In/100063470413843/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1375140880"
+  },
+  {
+   "id": "node/8023598981",
+   "name": "Cinnabon",
+   "address": "",
+   "lat": 40.5788738,
+   "lng": -75.5309544,
+   "types": [
+    "fast_food",
+    "dessert",
+    "takeaway"
+   ],
+   "cuisine": [
+    "dessert"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://locations.cinnabon.com/pa/allentown/3830-dorney-park-road",
+   "openingHours": null,
+   "brand": "Cinnabon",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8023598981"
+  },
+  {
+   "id": "node/10096025137",
+   "name": "Cinnabon",
+   "address": "Allentown Service Plaza",
+   "lat": 40.5743411,
+   "lng": -75.5576168,
+   "types": [
+    "fast_food",
+    "dessert",
+    "takeaway"
+   ],
+   "cuisine": [
+    "dessert"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://locations.cinnabon.com/pa/allentown/5052-cetronia-road",
+   "openingHours": null,
+   "brand": "Cinnabon",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10096025137"
+  },
+  {
+   "id": "node/9792860701",
+   "name": "Clewell Dining Hall",
+   "address": "348 Main Street, Bethlehem, PA",
+   "lat": 40.6184021,
+   "lng": -75.3822523,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9792860701"
+  },
+  {
+   "id": "way/860882497",
+   "name": "Clucks and Franks",
+   "address": "",
+   "lat": 40.5792534,
+   "lng": -75.5307463,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/clucks-and-franks",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860882497"
+  },
+  {
+   "id": "node/4461017811",
+   "name": "Clucky Cafe",
+   "address": "",
+   "lat": 40.5109595,
+   "lng": -75.3910573,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4461017811"
+  },
+  {
+   "id": "node/6312673771",
+   "name": "Clusters Handcrafted Popcorn",
+   "address": "530 Main Street, Bethlehem, PA",
+   "lat": 40.6212726,
+   "lng": -75.3818484,
+   "types": [
+    "fast_food",
+    "popcorn"
+   ],
+   "cuisine": [
+    "popcorn"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610 849 2576",
+   "website": "https://www.clusterspopcornbethlehem.com/",
+   "openingHours": "Mo-Su 12:00-18:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6312673771"
+  },
+  {
+   "id": "way/860882498",
+   "name": "Coasters Drive-In",
+   "address": "",
+   "lat": 40.5790902,
+   "lng": -75.5314274,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/coasters-drive-in",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860882498"
+  },
+  {
+   "id": "node/13025819364",
+   "name": "Coil",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145868,
+   "lng": -75.3573686,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819364"
+  },
+  {
+   "id": "node/7928986829",
+   "name": "Cold Stone Creamery",
+   "address": "",
+   "lat": 40.6122356,
+   "lng": -75.5352804,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Cold Stone Creamery",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928986829"
+  },
+  {
+   "id": "node/13027820561",
+   "name": "Colombian Mex Restaurant",
+   "address": "107 East Union Boulevard, Bethlehem, PA",
+   "lat": 40.6251113,
+   "lng": -75.374911,
+   "types": [
+    "restaurant",
+    "colombian"
+   ],
+   "cuisine": [
+    "colombian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13027820561"
+  },
+  {
+   "id": "way/857026268",
+   "name": "Commix Food & Spirits",
+   "address": "3245 West Emaus Avenue, Allentown, PA",
+   "lat": 40.5550726,
+   "lng": -75.4844414,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107979711",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/857026268"
+  },
+  {
+   "id": "way/348781824",
+   "name": "Constantino's Pizzeria & Ristorante",
+   "address": "",
+   "lat": 40.6692504,
+   "lng": -75.2742489,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/348781824"
+  },
+  {
+   "id": "way/223898172",
+   "name": "Coopersburg Diner",
+   "address": "336 North 3rd Street, Coopersburg, PA",
+   "lat": 40.5150512,
+   "lng": -75.3855137,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102821853",
+   "website": "https://www.coopersburgdiner.com/",
+   "openingHours": "07:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/223898172"
+  },
+  {
+   "id": "way/1305684828",
+   "name": "Coplay Eatery",
+   "address": "1214 North Ruch Street, Coplay, PA",
+   "lat": 40.6674888,
+   "lng": -75.5035517,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104400293",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1305684828"
+  },
+  {
+   "id": "way/1263743302",
+   "name": "Coplay Saengerbund",
+   "address": "",
+   "lat": 40.6681863,
+   "lng": -75.4908017,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1263743302"
+  },
+  {
+   "id": "way/1249380597",
+   "name": "Copperhead Grill",
+   "address": "5737 PA-378, Bethlehem, PA",
+   "lat": 40.5366887,
+   "lng": -75.3951008,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://copperheadgrille.com/",
+   "openingHours": "Mo-Su 11:00-22:00; Th-Sa 11:00-23:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1249380597"
+  },
+  {
+   "id": "way/1278087227",
+   "name": "Copperhead Grille Allentown",
+   "address": "1731 Airport Road, Allentown, PA",
+   "lat": 40.6347313,
+   "lng": -75.4380565,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104034600",
+   "website": "https://copperheadgrille.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278087227"
+  },
+  {
+   "id": "node/5821469649",
+   "name": "CoreLife Eatery",
+   "address": "",
+   "lat": 40.5647347,
+   "lng": -75.5620999,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469649"
+  },
+  {
+   "id": "way/1311899366",
+   "name": "Country View Diner",
+   "address": "6210 PA 873, Slatington, PA",
+   "lat": 40.7057586,
+   "lng": -75.6208774,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107601740",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1311899366"
+  },
+  {
+   "id": "node/5160211564",
+   "name": "Crab Du Jour",
+   "address": "1063 Grape Street, Whitehall, PA",
+   "lat": 40.6342698,
+   "lng": -75.4804653,
+   "types": [
+    "restaurant",
+    "seafood"
+   ],
+   "cuisine": [
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5160211564"
+  },
+  {
+   "id": "way/59416770",
+   "name": "Cracker Barrel",
+   "address": "7720 Main Street, Fogelsville, PA",
+   "lat": 40.5820895,
+   "lng": -75.626857,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Cracker Barrel",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/59416770"
+  },
+  {
+   "id": "node/5737375766",
+   "name": "Crave",
+   "address": "77 West Broad Street, Bethlehem, PA",
+   "lat": 40.6217461,
+   "lng": -75.3807496,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 905 0485",
+   "website": "https://www.cravebethlehem.com/",
+   "openingHours": "Mo-Sa 07:00-19:00; Su 11:00-19:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5737375766"
+  },
+  {
+   "id": "way/531116916",
+   "name": "Crazy Cones",
+   "address": "2525 Mickley Avenue, Whitehall, PA",
+   "lat": 40.6441382,
+   "lng": -75.4911609,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-434-1458",
+   "website": null,
+   "openingHours": "\"closed for the season\"",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531116916"
+  },
+  {
+   "id": "way/346603089",
+   "name": "Crossroads Hotel",
+   "address": "1443 Main Street, Hellertown, PA",
+   "lat": 40.5902604,
+   "lng": -75.3398093,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/346603089"
+  },
+  {
+   "id": "node/4633637891",
+   "name": "Cuchifrito Restaurant",
+   "address": "105 North 7th Street, Allentown",
+   "lat": 40.6038849,
+   "lng": -75.4722201,
+   "types": [
+    "restaurant",
+    "puerto_rican"
+   ],
+   "cuisine": [
+    "puerto_rican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4633637891"
+  },
+  {
+   "id": "node/12920538350",
+   "name": "Cumin N Eat",
+   "address": "3331 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.579078,
+   "lng": -75.5251999,
+   "types": [
+    "restaurant",
+    "indian"
+   ],
+   "cuisine": [
+    "indian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12920538350"
+  },
+  {
+   "id": "node/13260544501",
+   "name": "Cumin N Eat",
+   "address": "",
+   "lat": 40.6970196,
+   "lng": -75.5004518,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13260544501"
+  },
+  {
+   "id": "node/9810977723",
+   "name": "Cuquita Restaurant",
+   "address": "960 Broadway, Fountain Hill, PA",
+   "lat": 40.6034739,
+   "lng": -75.3911559,
+   "types": [
+    "restaurant",
+    "colombian"
+   ],
+   "cuisine": [
+    "colombian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9810977723"
+  },
+  {
+   "id": "node/9377956460",
+   "name": "D & S Caribbean Kitchen",
+   "address": "31 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6249603,
+   "lng": -75.3796037,
+   "types": [
+    "restaurant",
+    "caribbean"
+   ],
+   "cuisine": [
+    "caribbean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 3435",
+   "website": "https://d-skitchen.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9377956460"
+  },
+  {
+   "id": "node/11515316735",
+   "name": "D` Sopranos Pizza",
+   "address": "",
+   "lat": 40.7547354,
+   "lng": -75.5923945,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11515316735"
+  },
+  {
+   "id": "node/6923701401",
+   "name": "DaJudah's Kitchen",
+   "address": "189 Tilghman Street, Allentown, PA",
+   "lat": 40.6154937,
+   "lng": -75.4641598,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6923701401"
+  },
+  {
+   "id": "node/6925565831",
+   "name": "Damascus",
+   "address": "449 North 2nd Street, Allentown, PA",
+   "lat": 40.6124069,
+   "lng": -75.4629655,
+   "types": [
+    "restaurant",
+    "mediterranean"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [
+    "vegetarian"
+   ],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.damascusrestaurantpa.com/",
+   "openingHours": "Tu-Th 10:00-19:00; Fr,Sa 10:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6925565831"
+  },
+  {
+   "id": "node/12504695129",
+   "name": "Das Cerveza Haus",
+   "address": "663 Blue Mountain Drive, Cherryville, pa",
+   "lat": 40.7547539,
+   "lng": -75.5385022,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "24/7",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12504695129"
+  },
+  {
+   "id": "way/1281275475",
+   "name": "Dave & Buster's",
+   "address": "1491 MacArthur Road, Whitehall, PA",
+   "lat": 40.6289094,
+   "lng": -75.4832553,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14842456400",
+   "website": "https://www.daveandbusters.com/us/en/about/locations/lehigh",
+   "openingHours": null,
+   "brand": "Dave & Buster's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1281275475"
+  },
+  {
+   "id": "way/79291000",
+   "name": "DaVinci's Pizzeria",
+   "address": "2407 Mickley Avenue, Whitehall, PA",
+   "lat": 40.6428545,
+   "lng": -75.488861,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102571111",
+   "website": "https://thedavincipizzeria.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/79291000"
+  },
+  {
+   "id": "way/1369420977",
+   "name": "Deja Brew",
+   "address": "101 West 4th Street, Bethlehem, PA",
+   "lat": 40.6106183,
+   "lng": -75.3798481,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1369420977"
+  },
+  {
+   "id": "node/4848547211",
+   "name": "Delicioso Pizza & Subs",
+   "address": "1032 Hamilton Street, Allentown",
+   "lat": 40.6000385,
+   "lng": -75.479106,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4848547211"
+  },
+  {
+   "id": "way/1278351857",
+   "name": "DeLio's Subs & Steaks",
+   "address": "3360 Airport Road, Allentown, PA",
+   "lat": 40.656644,
+   "lng": -75.4278736,
+   "types": [
+    "fast_food",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16108417645",
+   "website": null,
+   "openingHours": "Mo-Fr 07:30-15:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278351857"
+  },
+  {
+   "id": "way/278759465",
+   "name": "Delizioso Italian Grill",
+   "address": "1985 Brookside Road, Macungie, PA",
+   "lat": 40.5468211,
+   "lng": -75.5515592,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103667166",
+   "website": "https://deliziosoitaliangrill.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278759465"
+  },
+  {
+   "id": "way/760404092",
+   "name": "Demarco's Italian Restaurant",
+   "address": "10240 Old US Highway 22, Kutztown, PA",
+   "lat": 40.5782526,
+   "lng": -75.7088952,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102852278",
+   "website": "https://foodeist.com/place/demarcositalianrestaurant",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/760404092"
+  },
+  {
+   "id": "way/51552681",
+   "name": "Denny's",
+   "address": "1881 Catasauqua Road, Allentown, PA",
+   "lat": 40.6409613,
+   "lng": -75.4313296,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Denny's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/51552681"
+  },
+  {
+   "id": "way/1312881904",
+   "name": "Di Fiore's Pizzeria & Italian Restaurant",
+   "address": "5608 PA 873, Neffs, PA",
+   "lat": 40.6925369,
+   "lng": -75.6097427,
+   "types": [
+    "restaurant",
+    "italian",
+    "pizza"
+   ],
+   "cuisine": [
+    "italian",
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107679116",
+   "website": "https://www.difiorespizzaitalianrestaurant.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1312881904"
+  },
+  {
+   "id": "way/432178294",
+   "name": "Diana's Catering & Gourmet Market",
+   "address": "4907 PA 309, Center Valley, PA",
+   "lat": 40.540159,
+   "lng": -75.413165,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107972525",
+   "website": "https://www.dianascateringandgourmetmarket.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/432178294"
+  },
+  {
+   "id": "node/10029232044",
+   "name": "Diggity Dog",
+   "address": "",
+   "lat": 40.7523943,
+   "lng": -75.6048675,
+   "types": [
+    "fast_food",
+    "hot_dog",
+    "breakfast",
+    "takeaway"
+   ],
+   "cuisine": [
+    "hot_dog",
+    "breakfast"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": "Mo-Su 06:00-17:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10029232044"
+  },
+  {
+   "id": "node/3531172122",
+   "name": "DiMaio's Family Ristorante & Pizzeria",
+   "address": "27 Main Street, Hellertown, PA",
+   "lat": 40.5684278,
+   "lng": -75.339305,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-838-8004",
+   "website": "https://dimaios.net",
+   "openingHours": "Mo-Th 11:00-21:30; Fr-Su 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3531172122"
+  },
+  {
+   "id": "node/11895267855",
+   "name": "Dino's Pizza-teria",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5554726,
+   "lng": -75.4915873,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11895267855"
+  },
+  {
+   "id": "way/232726125",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5804621,
+   "lng": -75.5322981,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232726125"
+  },
+  {
+   "id": "way/232833671",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5799382,
+   "lng": -75.5339653,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232833671"
+  },
+  {
+   "id": "way/860558094",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5792949,
+   "lng": -75.5361842,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860558094"
+  },
+  {
+   "id": "way/860923971",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5788323,
+   "lng": -75.5293163,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860923971"
+  },
+  {
+   "id": "way/861244732",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5784918,
+   "lng": -75.5310869,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/861244732"
+  },
+  {
+   "id": "way/864304163",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5786516,
+   "lng": -75.5275179,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/864304163"
+  },
+  {
+   "id": "way/864305953",
+   "name": "Dippin' Dots",
+   "address": "",
+   "lat": 40.5784818,
+   "lng": -75.5291096,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dippin' Dots",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/864305953"
+  },
+  {
+   "id": "node/12709754717",
+   "name": "Dom's Westgate Pizza",
+   "address": "2335 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.641953,
+   "lng": -75.4031213,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12709754717"
+  },
+  {
+   "id": "node/993739558",
+   "name": "Domino's",
+   "address": "1353 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6317052,
+   "lng": -75.3691031,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-865-2700",
+   "website": "https://pizza.dominos.com/pennsylvania/bethlehem/1353-easton-ave",
+   "openingHours": "Mo-Th 11:00-24:00; Fr-Sa 11:00-01:00; Su 11:00-24:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/993739558"
+  },
+  {
+   "id": "node/2358062068",
+   "name": "Domino's",
+   "address": "19 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6120941,
+   "lng": -75.3777451,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-861-0440",
+   "website": "https://pizza.dominos.com/pennsylvania/bethlehem/19-east-third-street",
+   "openingHours": "Mo-Th 10:30-01:00; Fr-Sa 10:30-02:00; Su 10:30-01:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2358062068"
+  },
+  {
+   "id": "node/5265691829",
+   "name": "Domino's",
+   "address": "859 Nazareth Pike, Nazareth, PA",
+   "lat": 40.7306115,
+   "lng": -75.3173302,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-746-0600",
+   "website": "https://pizza.dominos.com/pennsylvania/nazareth/859-nazareth-pike-bldg-c1",
+   "openingHours": "Mo-Th 10:30-24:00; Fr-Sa 10:30-01:00; Su 10:30-24:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5265691829"
+  },
+  {
+   "id": "node/5800087366",
+   "name": "Domino's",
+   "address": "4229 Tilghman Street, Allentown, PA",
+   "lat": 40.5916333,
+   "lng": -75.5514553,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-395-1515",
+   "website": "https://pizza.dominos.com/pennsylvania/allentown/4229-tilghman-st",
+   "openingHours": "Mo-Th 10:30-24:00; Fr-Sa 10:30-01:00; Su 10:30-24:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087366"
+  },
+  {
+   "id": "node/6904198069",
+   "name": "Domino's",
+   "address": "1826 Union Boulevard, Allentown, PA",
+   "lat": 40.6252803,
+   "lng": -75.4280949,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-776-2020",
+   "website": "https://pizza.dominos.com/pennsylvania/allentown/1826-union-blvd",
+   "openingHours": "Mo-Th 10:30-01:00; Fr-Sa 10:30-02:00; Su 10:30-01:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904198069"
+  },
+  {
+   "id": "node/7928570055",
+   "name": "Domino's",
+   "address": "315 South Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.5831176,
+   "lng": -75.5217348,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928570055"
+  },
+  {
+   "id": "node/8977651393",
+   "name": "Domino's",
+   "address": "695 State Road, Emmaus, PA",
+   "lat": 40.5530345,
+   "lng": -75.4904382,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-967-4111",
+   "website": "https://pizza.dominos.com/pennsylvania/emmaus/695-state-road",
+   "openingHours": "Mo-Th 10:30-24:00; Fr-Sa 10:30-01:00; Su 10:30-24:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8977651393"
+  },
+  {
+   "id": "node/11077932953",
+   "name": "Domino's",
+   "address": "7720 Main Street, Fogelsville, PA",
+   "lat": 40.5826279,
+   "lng": -75.6278442,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-915-2500",
+   "website": "https://pizza.dominos.com/pennsylvania/fogelsville/7720-main-st",
+   "openingHours": "Mo-Th 10:30-24:00; Fr-Sa 10:30-01:00; Su 10:30-24:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11077932953"
+  },
+  {
+   "id": "node/12682072349",
+   "name": "Domino's",
+   "address": "155 Mickley Road, Whitehall, PA",
+   "lat": 40.6206069,
+   "lng": -75.4817211,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682072349"
+  },
+  {
+   "id": "node/13060096947",
+   "name": "Domino's",
+   "address": "20 Main Street, Slatington, PA",
+   "lat": 40.7531618,
+   "lng": -75.6039579,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16107601234",
+   "website": null,
+   "openingHours": null,
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13060096947"
+  },
+  {
+   "id": "way/432648083",
+   "name": "Domino's",
+   "address": "3752 PA 309, Orefield, PA",
+   "lat": 40.6508892,
+   "lng": -75.5987841,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-601-0101",
+   "website": "https://pizza.dominos.com/pennsylvania/orefield/3752-pa-route-309",
+   "openingHours": "Mo-Th,Su 10:30-24:00; Fr-Sa 10:30-25:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/432648083"
+  },
+  {
+   "id": "way/449215242",
+   "name": "Domino's",
+   "address": "1010 Chestnut Street, Emmaus, PA",
+   "lat": 40.529429,
+   "lng": -75.5042541,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-967-4111",
+   "website": "https://pizza.dominos.com/pennsylvania/emmaus/1010-chestnut-st",
+   "openingHours": "Mo-Th,Su 10:30-24:00, Fr-Sa 10:30-01:00",
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/449215242"
+  },
+  {
+   "id": "way/1444418449",
+   "name": "Domino's",
+   "address": "2 East Susquehanna Street, Allentown, PA",
+   "lat": 40.5904164,
+   "lng": -75.4529773,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16107098644",
+   "website": null,
+   "openingHours": null,
+   "brand": "Domino's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1444418449"
+  },
+  {
+   "id": "way/641903676",
+   "name": "Don Juan Mex Grill & Cantina",
+   "address": "",
+   "lat": 40.5477249,
+   "lng": -75.5518806,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/641903676"
+  },
+  {
+   "id": "node/11893016947",
+   "name": "Don Juan Mexican Grill",
+   "address": "7751 Glenlivet Drive West, Fogelsville, PA",
+   "lat": 40.5906003,
+   "lng": -75.6305161,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11893016947"
+  },
+  {
+   "id": "node/7937971902",
+   "name": "Don Juan's",
+   "address": "",
+   "lat": 40.5265717,
+   "lng": -75.5096949,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971902"
+  },
+  {
+   "id": "node/12686201436",
+   "name": "Donerds Donuts",
+   "address": "3 East 4th Street, Bethlehem, PA",
+   "lat": 40.6105659,
+   "lng": -75.3781687,
+   "types": [
+    "fast_food",
+    "donut"
+   ],
+   "cuisine": [
+    "donut"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12686201436"
+  },
+  {
+   "id": "way/350676882",
+   "name": "DQ Grill & Chill",
+   "address": "2910 Easton Avenue, Bethlehem, PA",
+   "lat": 40.647868,
+   "lng": -75.3404059,
+   "types": [
+    "fast_food",
+    "ice_cream",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "ice_cream",
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-814-2714",
+   "website": "https://www.dairyqueen.com/locations/pa/bethlehem/2910-easton-ave/10791",
+   "openingHours": null,
+   "brand": "DQ Grill & Chill",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/350676882"
+  },
+  {
+   "id": "node/6923619217",
+   "name": "Dragon Palace",
+   "address": "",
+   "lat": 40.6298679,
+   "lng": -75.4399013,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6923619217"
+  },
+  {
+   "id": "node/6307326504",
+   "name": "Drake's Pizza",
+   "address": "1452 Pennsylvania Avenue, Allentown, PA",
+   "lat": 40.6354409,
+   "lng": -75.4237187,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6307326504"
+  },
+  {
+   "id": "node/8443747508",
+   "name": "Drizzle Ice Cream of Alburtis",
+   "address": "47 West Penn Avenue, Alburtis, PA",
+   "lat": 40.5122194,
+   "lng": -75.605647,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8443747508"
+  },
+  {
+   "id": "node/9756023590",
+   "name": "Duck Donuts",
+   "address": "4403 Southmont Way, Easton, PA",
+   "lat": 40.6556631,
+   "lng": -75.2858637,
+   "types": [
+    "fast_food",
+    "donut",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-373-9233",
+   "website": "https://order.duckdonuts.com/menu/duck-donuts-easton",
+   "openingHours": "07:00-19:00",
+   "brand": "Duck Donuts",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9756023590"
+  },
+  {
+   "id": "node/10088687984",
+   "name": "Duck Donuts",
+   "address": "4608 Broadway, Allentown, PA",
+   "lat": 40.5863034,
+   "lng": -75.5582729,
+   "types": [
+    "fast_food",
+    "donut",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Duck Donuts",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10088687984"
+  },
+  {
+   "id": "node/7273704285",
+   "name": "Duncan’s Blue Lantern",
+   "address": "3328 Valley View Drive",
+   "lat": 40.7527279,
+   "lng": -75.4707412,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-440-2583",
+   "website": "http://duncansbluelantern.com",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7273704285"
+  },
+  {
+   "id": "node/10635418734",
+   "name": "Dunderbak's Market Cafe",
+   "address": "121 Lehigh Valley Mall, Whitehall, PA",
+   "lat": 40.6295244,
+   "lng": -75.479255,
+   "types": [
+    "restaurant",
+    "german"
+   ],
+   "cuisine": [
+    "german"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10635418734"
+  },
+  {
+   "id": "node/993745814",
+   "name": "Dunkin'",
+   "address": "1301 Linden Street, Bethlehem, PA",
+   "lat": 40.6307289,
+   "lng": -75.3706353,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-866-9030",
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/1301-linden-st/345408",
+   "openingHours": "05:00-20:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/993745814"
+  },
+  {
+   "id": "node/3561965409",
+   "name": "Dunkin'",
+   "address": "4460 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6660381,
+   "lng": -75.3078543,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 267-621-4817",
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/4460-easton-ave/340538",
+   "openingHours": "05:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3561965409"
+  },
+  {
+   "id": "node/7929108215",
+   "name": "Dunkin'",
+   "address": "1403 North Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.612129,
+   "lng": -75.5319375,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-477-4887",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/1403-n-cedar-crest-blvd/346805",
+   "openingHours": "Mo-Fr 05:00-19:00; Sa-Su 06:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7929108215"
+  },
+  {
+   "id": "node/7940735392",
+   "name": "Dunkin'",
+   "address": "4030 Chestnut Street, Emmaus, PA",
+   "lat": 40.5201366,
+   "lng": -75.5211372,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-966-4160",
+   "website": "https://locations.dunkindonuts.com/en/pa/emmaus/4030-chestnut-st/346220",
+   "openingHours": "05:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7940735392"
+  },
+  {
+   "id": "node/9319487783",
+   "name": "Dunkin'",
+   "address": "3626 Route 309, Orefield, PA",
+   "lat": 40.647447,
+   "lng": -75.5952957,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-391-1182",
+   "website": "https://locations.dunkindonuts.com/en/pa/orefield/3626-route-309/344415",
+   "openingHours": "Mo-Sa 04:30-20:00; Su 06:00-20:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9319487783"
+  },
+  {
+   "id": "node/9401055488",
+   "name": "Dunkin'",
+   "address": "4793 West Tilghman Street, Allentown, PA",
+   "lat": 40.5900344,
+   "lng": -75.5623468,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-395-5770",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/4793-w-tilghman-st/308570",
+   "openingHours": "Mo-Sa 05:00-19:00; Su 06:00-15:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9401055488"
+  },
+  {
+   "id": "node/13019488587",
+   "name": "Dunkin'",
+   "address": "Allentown Service Plaza",
+   "lat": 40.5742688,
+   "lng": -75.557999,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019488587"
+  },
+  {
+   "id": "node/13033482084",
+   "name": "Dunkin'",
+   "address": "1928 Hamilton Street, Allentown, PA",
+   "lat": 40.5943933,
+   "lng": -75.4974312,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033482084"
+  },
+  {
+   "id": "node/13127845410",
+   "name": "Dunkin'",
+   "address": "6366 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5553454,
+   "lng": -75.5801473,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-7201",
+   "website": "https://locations.dunkindonuts.com/en/pa/trexlertown/6366-hamilton-blvd/342836",
+   "openingHours": "Mo-Sa 05:00-21:00; Su 06:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13127845410"
+  },
+  {
+   "id": "way/43567722",
+   "name": "Dunkin'",
+   "address": "213 West 4th Street, Bethlehem, PA",
+   "lat": 40.6105536,
+   "lng": -75.3820665,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/213-w.-4th-st/345459",
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/43567722"
+  },
+  {
+   "id": "way/51552683",
+   "name": "Dunkin'",
+   "address": "1870 Catasauqua Road, Allentown, PA",
+   "lat": 40.6401781,
+   "lng": -75.4303963,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-264-2890",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/1870-catasauqua-rd/339782",
+   "openingHours": "Mo-Sa 05:00-21:00; Su 06:00-20:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/51552683"
+  },
+  {
+   "id": "way/53637203",
+   "name": "Dunkin'",
+   "address": "3219 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5797126,
+   "lng": -75.5230919,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-770-9466",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/3219-hamilton-blvd/331199",
+   "openingHours": "Mo-Sa 05:00-21:00; Su 06:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/53637203"
+  },
+  {
+   "id": "way/115938550",
+   "name": "Dunkin'",
+   "address": "730 Main Street, Hellertown, PA",
+   "lat": 40.5799693,
+   "lng": -75.3413341,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-851-3051",
+   "website": "https://locations.dunkindonuts.com/en/pa/hellertown/730-main-st/350079",
+   "openingHours": "Mo-Sa 05:00-19:00; Su 06:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/115938550"
+  },
+  {
+   "id": "way/148905708",
+   "name": "Dunkin'",
+   "address": "3055 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6518952,
+   "lng": -75.4133389,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-866-6868",
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/3055-schoenersville-rd/332008",
+   "openingHours": "Mo-Sa 05:00-21:30; Su 06:00-20:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/148905708"
+  },
+  {
+   "id": "way/205275827",
+   "name": "Dunkin'",
+   "address": "3606 Linden Street, Bethlehem, PA",
+   "lat": 40.6690634,
+   "lng": -75.3477368,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-865-2299",
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/3606-linden-st/342904",
+   "openingHours": "Mo 05:00-19:00; Tu 05:00-19:30; We 05:00-19:00; Th-Sa 05:00-19:30; Su 06:00-17:30",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/205275827"
+  },
+  {
+   "id": "way/223898293",
+   "name": "Dunkin'",
+   "address": "3655 Route 378, Bethlehem, PA",
+   "lat": 40.583708,
+   "lng": -75.3869841,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 267-621-4818",
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/3655-route-378/345222",
+   "openingHours": "05:00-18:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/223898293"
+  },
+  {
+   "id": "way/268712951",
+   "name": "Dunkin'",
+   "address": "1910 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6401918,
+   "lng": -75.3472719,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-867-3597",
+   "website": "https://locations.dunkindonuts.com/en/pa/bethlehem/1910-stefko-blvd/301638",
+   "openingHours": "05:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/268712951"
+  },
+  {
+   "id": "way/278142364",
+   "name": "Dunkin'",
+   "address": "1679 Nor-Bath Pike, Northampton, PA",
+   "lat": 40.6944503,
+   "lng": -75.4898482,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-590-4648",
+   "website": "https://locations.dunkindonuts.com/en/pa/northampton/1679-nor-bath-blvd/342969",
+   "openingHours": "Mo-Sa 05:00-20:00; Su 06:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278142364"
+  },
+  {
+   "id": "way/278451739",
+   "name": "Dunkin'",
+   "address": "3670 MacArthur Road, Whitehall, PA",
+   "lat": 40.6647682,
+   "lng": -75.5120878,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-440-0317",
+   "website": "https://locations.dunkindonuts.com/en/pa/whitehall/3670-macarthur-rd/349173",
+   "openingHours": "Mo-Sa 04:00-22:00; Su 05:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278451739"
+  },
+  {
+   "id": "way/351727024",
+   "name": "Dunkin'",
+   "address": "318 South 3rd Street, Coopersburg, PA",
+   "lat": 40.5065318,
+   "lng": -75.3872241,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-282-2021",
+   "website": "https://locations.dunkindonuts.com/en/pa/coopersburg/318-s-3rd-st/346982",
+   "openingHours": "Mo-Fr 05:00-21:00; Sa 06:00-15:00; Su 06:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/351727024"
+  },
+  {
+   "id": "way/478905326",
+   "name": "Dunkin'",
+   "address": "4777 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5677978,
+   "lng": -75.5509488,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-9235",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/4777-hamilton-blvd/341980",
+   "openingHours": "Mo-Sa 05:00-22:00; Su 06:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/478905326"
+  },
+  {
+   "id": "way/531116938",
+   "name": "Dunkin'",
+   "address": "2364 MacArthur Road, Whitehall, PA",
+   "lat": 40.6414037,
+   "lng": -75.4907655,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-433-4800",
+   "website": "https://locations.dunkindonuts.com/en/pa/whitehall/2364-macarthur-rd/330080",
+   "openingHours": "Mo-Sa 05:00-19:00; Su 06:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531116938"
+  },
+  {
+   "id": "way/531304196",
+   "name": "Dunkin'",
+   "address": "2267 MacArthur Road, Whitehall, PA",
+   "lat": 40.6396817,
+   "lng": -75.4890013,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-776-2300",
+   "website": "https://locations.dunkindonuts.com/en/pa/whitehall/2267-macarthur-road/345514",
+   "openingHours": "Mo-Sa 06:00-19:00; Su 07:00-19:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531304196"
+  },
+  {
+   "id": "way/763277914",
+   "name": "Dunkin'",
+   "address": "5831 Tilghman Street, Allentown, PA",
+   "lat": 40.5921639,
+   "lng": -75.5905737,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-1916",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/5831-w-tilghman-st/351205",
+   "openingHours": "Mo-Su 08:00-23:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/763277914"
+  },
+  {
+   "id": "way/1035394711",
+   "name": "Dunkin'",
+   "address": "",
+   "lat": 40.6698331,
+   "lng": -75.3847702,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1035394711"
+  },
+  {
+   "id": "way/1256886087",
+   "name": "Dunkin'",
+   "address": "1547 Lehigh Street, Allentown, PA",
+   "lat": 40.5783824,
+   "lng": -75.4803189,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-9289",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/1547-lehigh-st/352531",
+   "openingHours": "Mo-Fr 04:30-21:00; Sa 04:30-20:00; Su 06:00-20:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1256886087"
+  },
+  {
+   "id": "way/1278087226",
+   "name": "Dunkin'",
+   "address": "261 Lloyd Street, Allentown, PA",
+   "lat": 40.6331792,
+   "lng": -75.4397222,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-443-3300",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/261-lloyd-st/350139",
+   "openingHours": "05:00-21:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278087226"
+  },
+  {
+   "id": "way/1278681629",
+   "name": "Dunkin'",
+   "address": "7721 Glenlivet Drive West, Fogelsville, PA",
+   "lat": 40.5905621,
+   "lng": -75.6297784,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278681629"
+  },
+  {
+   "id": "way/1302652378",
+   "name": "Dunkin'",
+   "address": "1174 MacArthur Road, Whitehall, PA",
+   "lat": 40.6213226,
+   "lng": -75.4812685,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1302652378"
+  },
+  {
+   "id": "way/1363445536",
+   "name": "Dunkin'",
+   "address": "3111 Lehigh Street, Allentown, PA",
+   "lat": 40.558117,
+   "lng": -75.4878807,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-253-6304",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/3111-lehigh-st/354593",
+   "openingHours": "Mo-Tu,Th-Fr 05:00-20:00; We 05:00-16:00; Sa-Su 05:00-18:00",
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1363445536"
+  },
+  {
+   "id": "way/1435274148",
+   "name": "Dunkin'",
+   "address": "2160 Golden Key Road, Kutztown, PA",
+   "lat": 40.5791545,
+   "lng": -75.7084837,
+   "types": [
+    "fast_food",
+    "donut",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "donut",
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Dunkin'",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1435274148"
+  },
+  {
+   "id": "way/533660827",
+   "name": "East Penn Diner",
+   "address": "1418 Chestnut Street, Emmaus, PA",
+   "lat": 40.5261716,
+   "lng": -75.5106369,
+   "types": [
+    "restaurant",
+    "greek",
+    "american",
+    "takeaway"
+   ],
+   "cuisine": [
+    "greek",
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-965-3100",
+   "website": "https://eastpenndiner.com/",
+   "openingHours": "Mo-Sa 06:00-22:00; Su 06:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/533660827"
+  },
+  {
+   "id": "way/1278087241",
+   "name": "East Siders Bar & Grill",
+   "address": "2204 Union Boulevard, Allentown, PA",
+   "lat": 40.6256968,
+   "lng": -75.4230893,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278087241"
+  },
+  {
+   "id": "node/5760482715",
+   "name": "Eastern Gourmet",
+   "address": "7001 North Route 309, Coopersburg, PA",
+   "lat": 40.5179284,
+   "lng": -75.3872358,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5760482715"
+  },
+  {
+   "id": "node/3575589718",
+   "name": "Ecco Domani",
+   "address": "216 East Fairmount Street, Coopersburg, PA",
+   "lat": 40.5168719,
+   "lng": -75.3847396,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3575589718"
+  },
+  {
+   "id": "node/831649327",
+   "name": "Edge Restaurant",
+   "address": "74 West Broad Street, Bethlehem, PA",
+   "lat": 40.6225379,
+   "lng": -75.3813582,
+   "types": [
+    "restaurant",
+    "french",
+    "asian_fusion"
+   ],
+   "cuisine": [
+    "french",
+    "asian_fusion"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-814-0100",
+   "website": "https://edgerestaurant.net/",
+   "openingHours": "Mo-Sa 16:00-02:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649327"
+  },
+  {
+   "id": "way/666301651",
+   "name": "El Carbonaso Peruvian Restaurant",
+   "address": "2185 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6260965,
+   "lng": -75.4196525,
+   "types": [
+    "restaurant",
+    "peruvian",
+    "takeaway"
+   ],
+   "cuisine": [
+    "peruvian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Long John Silver's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/666301651"
+  },
+  {
+   "id": "node/6925565856",
+   "name": "El Castillo del Caribe",
+   "address": "346 Ridge Avenue, Allentown",
+   "lat": 40.6114697,
+   "lng": -75.4606498,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6925565856"
+  },
+  {
+   "id": "node/5898000860",
+   "name": "El Jefe's Taqueria",
+   "address": "506 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6120191,
+   "lng": -75.3716277,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 2000",
+   "website": "https://www.eljefestaqueria.com/",
+   "openingHours": "Mo-Su 08:00-03:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5898000860"
+  },
+  {
+   "id": "node/6344053007",
+   "name": "El Paisano Taqueria",
+   "address": "22 East Union Boulevard, Bethlehem, PA",
+   "lat": 40.6249001,
+   "lng": -75.3774456,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6344053007"
+  },
+  {
+   "id": "node/6943186651",
+   "name": "El Patron",
+   "address": "405 North 7th Street, Allentown, PA",
+   "lat": 40.6080525,
+   "lng": -75.4742758,
+   "types": [
+    "fast_food",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943186651"
+  },
+  {
+   "id": "node/6219816345",
+   "name": "Elias Grilled",
+   "address": "",
+   "lat": 40.6431002,
+   "lng": -75.3456253,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6219816345"
+  },
+  {
+   "id": "node/13022239171",
+   "name": "Elsa La Reina Del Chicharron",
+   "address": "1137 West Hamilton Street, Allentown, PA",
+   "lat": 40.5997414,
+   "lng": -75.4812554,
+   "types": [
+    "restaurant",
+    "dominican"
+   ],
+   "cuisine": [
+    "dominican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022239171"
+  },
+  {
+   "id": "node/13061217822",
+   "name": "Emiliano's Pizzeria",
+   "address": "757 Saint John Street, Allentown, PA",
+   "lat": 40.5918024,
+   "lng": -75.4685848,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061217822"
+  },
+  {
+   "id": "way/851185779",
+   "name": "Emmaus Community Pool Concessions Stand",
+   "address": "",
+   "lat": 40.5237264,
+   "lng": -75.5111929,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/851185779"
+  },
+  {
+   "id": "way/846603309",
+   "name": "Emmaus Fire Co. #1",
+   "address": "50 South 6th Street, Emmaus, PA",
+   "lat": 40.5314562,
+   "lng": -75.4951168,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109671400",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846603309"
+  },
+  {
+   "id": "node/13019949203",
+   "name": "Empanadas Monumental",
+   "address": "",
+   "lat": 40.615305,
+   "lng": -75.4447987,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019949203"
+  },
+  {
+   "id": "way/793972854",
+   "name": "Essentials Cafe",
+   "address": "418 3rd Avenue, Bethlehem, PA",
+   "lat": 40.6200917,
+   "lng": -75.3879507,
+   "types": [
+    "cafe",
+    "breakfast",
+    "lunch"
+   ],
+   "cuisine": [
+    "breakfast",
+    " lunch"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.essentialscafe.org/",
+   "openingHours": "Tu-Sa 08:00-14:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/793972854"
+  },
+  {
+   "id": "way/1446550531",
+   "name": "F & S Bar",
+   "address": "1008 Lehigh Street, Allentown, PA",
+   "lat": 40.588893,
+   "lng": -75.4738946,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1446550531"
+  },
+  {
+   "id": "way/43000812",
+   "name": "F&A Grog House",
+   "address": "117 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6122951,
+   "lng": -75.376485,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/43000812"
+  },
+  {
+   "id": "node/6338872239",
+   "name": "Familia Pizza",
+   "address": "739 Linden Street, Bethlehem, PA",
+   "lat": 40.6245861,
+   "lng": -75.3706674,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338872239"
+  },
+  {
+   "id": "node/13025819354",
+   "name": "Far East",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145481,
+   "lng": -75.3584257,
+   "types": [
+    "fast_food",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819354"
+  },
+  {
+   "id": "way/1444081200",
+   "name": "Fearless Fire Co. #14",
+   "address": "1221 South Front Street, Allentown, PA",
+   "lat": 40.589789,
+   "lng": -75.4528042,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1444081200"
+  },
+  {
+   "id": "node/1585847873",
+   "name": "Feasta Italiana",
+   "address": "2400 Schoenersville Road, Allentown, PA",
+   "lat": 40.659489,
+   "lng": -75.4207564,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1585847873"
+  },
+  {
+   "id": "node/259618819",
+   "name": "Feasta Pizza",
+   "address": "1826 Leithsville Road, Hellertown, PA",
+   "lat": 40.5640455,
+   "lng": -75.3398291,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-838-3330",
+   "website": "https://www.orderfeastapizza.com/",
+   "openingHours": "11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/259618819"
+  },
+  {
+   "id": "way/350989162",
+   "name": "Feasta Pizza",
+   "address": "",
+   "lat": 40.6422075,
+   "lng": -75.3208864,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/350989162"
+  },
+  {
+   "id": "node/831649283",
+   "name": "Fegley's Bethlehem Brew Works",
+   "address": "569 Main Street, Bethlehem",
+   "lat": 40.6222647,
+   "lng": -75.3821876,
+   "types": [
+    "restaurant",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-882-1300",
+   "website": "http://www.thebrewworks.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649283"
+  },
+  {
+   "id": "node/7681823947",
+   "name": "Fiamma",
+   "address": "2118 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6399302,
+   "lng": -75.3991896,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7681823947"
+  },
+  {
+   "id": "way/696979790",
+   "name": "Fiorentina Grill",
+   "address": "1106 Trexlertown Road, Trexlertown, PA",
+   "lat": 40.5507606,
+   "lng": -75.607268,
+   "types": [
+    "restaurant",
+    "italian",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108415666",
+   "website": "https://www.fiorentinagrill.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/696979790"
+  },
+  {
+   "id": "node/5800087247",
+   "name": "Five Guys",
+   "address": "4025 Tilghman Street, Allentown, PA",
+   "lat": 40.5934554,
+   "lng": -75.5449055,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-336-9315",
+   "website": "https://restaurants.fiveguys.com/4025-tilghman-street",
+   "openingHours": "11:00-21:30",
+   "brand": "Five Guys",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087247"
+  },
+  {
+   "id": "node/12437544971",
+   "name": "Five Guys",
+   "address": "3045 Center Valley Parkway, Center Valley, PA",
+   "lat": 40.5589341,
+   "lng": -75.4130431,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-709-8636",
+   "website": "https://restaurants.fiveguys.com/3045-center-valley-pkwy",
+   "openingHours": "10:00-22:00",
+   "brand": "Five Guys",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12437544971"
+  },
+  {
+   "id": "node/13176983220",
+   "name": "Five Guys",
+   "address": "2419 MacArthur Road, Whitehall, PA",
+   "lat": 40.6421981,
+   "lng": -75.4898881,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 484-387-1016",
+   "website": "https://restaurants.fiveguys.com/2401-2419-macarthur-road",
+   "openingHours": "11:00-22:00",
+   "brand": "Five Guys",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13176983220"
+  },
+  {
+   "id": "way/965431628",
+   "name": "Five Guys",
+   "address": "914 Airport Center Drive, Allentown, PA",
+   "lat": 40.6388663,
+   "lng": -75.4385897,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-266-5135",
+   "website": "https://restaurants.fiveguys.com/914-airport-center-drive",
+   "openingHours": "11:00-21:30",
+   "brand": "Five Guys",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/965431628"
+  },
+  {
+   "id": "node/6337896496",
+   "name": "Flama Tropical",
+   "address": "559 East Broad Street, Bethlehem, PA",
+   "lat": 40.6222648,
+   "lng": -75.3643661,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6337896496"
+  },
+  {
+   "id": "node/11905018577",
+   "name": "Flaming Crab Express",
+   "address": "1433 Allen Street, Allentown, PA",
+   "lat": 40.6066636,
+   "lng": -75.4913391,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905018577"
+  },
+  {
+   "id": "node/5160211565",
+   "name": "Flaming Grill & Supreme Buffet",
+   "address": "1055 Grape Street, Whitehall, PA",
+   "lat": 40.6344487,
+   "lng": -75.4805751,
+   "types": [
+    "restaurant",
+    "chinese",
+    "asian"
+   ],
+   "cuisine": [
+    "chinese",
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5160211565"
+  },
+  {
+   "id": "node/6909493849",
+   "name": "Flaming Hot Halal Grill",
+   "address": "768 Union Boulevard, Allentown, PA",
+   "lat": 40.6238252,
+   "lng": -75.4450034,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [
+    "halal"
+   ],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493849"
+  },
+  {
+   "id": "node/6341470175",
+   "name": "Flying Pig Tavern & Tap",
+   "address": "1313 Center Street, Bethlehem, PA",
+   "lat": 40.6311483,
+   "lng": -75.375363,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-871-5150",
+   "website": "https://flyingpigbethlehem.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6341470175"
+  },
+  {
+   "id": "way/1187839890",
+   "name": "Foundation Tavern",
+   "address": "1160 South Krocks Road, Wescosville, PA",
+   "lat": 40.5564094,
+   "lng": -75.5678097,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1187839890"
+  },
+  {
+   "id": "node/13360604503",
+   "name": "Four Monkeys Coffee",
+   "address": "1151 Mosser Road, Breinigsville, PA",
+   "lat": 40.5470281,
+   "lng": -75.6110988,
+   "types": [
+    "cafe",
+    "coffee_shop"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 972-8682",
+   "website": "https://fourmonkeyscoffee.square.site/",
+   "openingHours": "Sa 09:00-12:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13360604503"
+  },
+  {
+   "id": "node/9875328399",
+   "name": "Fragnito's Place",
+   "address": "55 South 2nd Street, Coplay, PA",
+   "lat": 40.6716977,
+   "lng": -75.4898116,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9875328399"
+  },
+  {
+   "id": "node/2069763285",
+   "name": "Francisco's Salvadoreño Restaurant",
+   "address": "100 East Broad Street, Bethlehem, PA",
+   "lat": 40.6220811,
+   "lng": -75.3751932,
+   "types": [
+    "restaurant",
+    "salvadoran"
+   ],
+   "cuisine": [
+    "salvadoran"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-866-3556",
+   "website": null,
+   "openingHours": "Su 14:00-21:00,Mo 10:00-21:00, We-Sa 10:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2069763285"
+  },
+  {
+   "id": "node/11820457512",
+   "name": "Frank's Pizza",
+   "address": "3926 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6735111,
+   "lng": -75.3417445,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11820457512"
+  },
+  {
+   "id": "node/5762218343",
+   "name": "Frank's Trattoria",
+   "address": "",
+   "lat": 40.4605039,
+   "lng": -75.3722733,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5762218343"
+  },
+  {
+   "id": "node/9756023597",
+   "name": "Franks Pizza & Italian Restaurant",
+   "address": "4422 Birkland Place, Easton, PA",
+   "lat": 40.6560539,
+   "lng": -75.285795,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9756023597"
+  },
+  {
+   "id": "node/904053578",
+   "name": "Fratelli Pizza",
+   "address": "1230 North New Street, Bethlehem, PA",
+   "lat": 40.6308782,
+   "lng": -75.3779107,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/904053578"
+  },
+  {
+   "id": "node/6916134241",
+   "name": "Freddie's Bar",
+   "address": "222 East Hamilton Street, Allentown, PA",
+   "lat": 40.6079389,
+   "lng": -75.4502764,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107760383",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6916134241"
+  },
+  {
+   "id": "node/8946729269",
+   "name": "Freddy and Chino's Place",
+   "address": "7567 Chestnut Street, Zionsville, PA",
+   "lat": 40.4641949,
+   "lng": -75.548722,
+   "types": [
+    "restaurant",
+    "burger",
+    "sandwich",
+    "soup",
+    "salad",
+    "wrap"
+   ],
+   "cuisine": [
+    "burger",
+    "sandwich",
+    "soup",
+    "salad",
+    "wrap"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-702-4270",
+   "website": "https://freddyandchinosplace.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8946729269"
+  },
+  {
+   "id": "way/266642520",
+   "name": "Friendly's",
+   "address": "6894 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5516558,
+   "lng": -75.5930452,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-395-1917",
+   "website": "https://locations.friendlysrestaurants.com/ll/US/PA/Trexlertown/6894-hamilton-blvd-po-box-859/",
+   "openingHours": "Mo-Th,Su 11:00-21:00; Fr-Sa 11:00-22:00",
+   "brand": "Friendly's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266642520"
+  },
+  {
+   "id": "node/7937952179",
+   "name": "Fuel Nutritional Smoothie Cafe",
+   "address": "",
+   "lat": 40.527932,
+   "lng": -75.5091363,
+   "types": [
+    "fast_food",
+    "juice"
+   ],
+   "cuisine": [
+    "juice"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937952179"
+  },
+  {
+   "id": "node/671546368",
+   "name": "FunHouse",
+   "address": "5 East 4th Street, Bethlehem, PA",
+   "lat": 40.6105635,
+   "lng": -75.378089,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/671546368"
+  },
+  {
+   "id": "way/232833644",
+   "name": "Funnel Cake & Soft Serve",
+   "address": "",
+   "lat": 40.5797,
+   "lng": -75.5336176,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/funnel-cake-soft-serve",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232833644"
+  },
+  {
+   "id": "way/1377791012",
+   "name": "Geakers at the Zoo",
+   "address": "",
+   "lat": 40.6581907,
+   "lng": -75.6262675,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1377791012"
+  },
+  {
+   "id": "node/4850469715",
+   "name": "Geakers Tacos",
+   "address": "",
+   "lat": 40.641541,
+   "lng": -75.3267221,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4850469715"
+  },
+  {
+   "id": "node/12686201454",
+   "name": "General Zapata Mexican Restaurant",
+   "address": "",
+   "lat": 40.6105765,
+   "lng": -75.3775799,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12686201454"
+  },
+  {
+   "id": "way/148905682",
+   "name": "George's Oasis Restaurant",
+   "address": "2355 Schoenersville Road, Allentown, PA",
+   "lat": 40.660149,
+   "lng": -75.4205314,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/148905682"
+  },
+  {
+   "id": "node/5794800234",
+   "name": "Ginza Sushi",
+   "address": "1903 West Broad Street, Bethlehem, PA",
+   "lat": 40.6234818,
+   "lng": -75.4116981,
+   "types": [
+    "fast_food",
+    "sushi",
+    "japanese"
+   ],
+   "cuisine": [
+    "sushi",
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5794800234"
+  },
+  {
+   "id": "node/13343473201",
+   "name": "Giovanni's Pizza",
+   "address": "1001 North 19th Street",
+   "lat": 40.6099772,
+   "lng": -75.5032158,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.giovannisallentown.com/",
+   "openingHours": "Mo-Th 10:00-21:00; Fr-Sa 10:00-22:00; Su 12:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13343473201"
+  },
+  {
+   "id": "node/735970362",
+   "name": "Godfrey Daniels",
+   "address": "7 East 4th Street, Bethlehem, PA",
+   "lat": 40.6105649,
+   "lng": -75.3779432,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/735970362"
+  },
+  {
+   "id": "way/1281275477",
+   "name": "Golden Corral",
+   "address": "900 Lehigh Valley Mall, Whitehall, PA",
+   "lat": 40.6292299,
+   "lng": -75.476703,
+   "types": [
+    "restaurant",
+    "american",
+    "buffet"
+   ],
+   "cuisine": [
+    "american",
+    "buffet"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104430866",
+   "website": "https://www.goldencorral.com/locations/location-detail/2627/golden-corral-lehigh-valley-mall/",
+   "openingHours": null,
+   "brand": "Golden Corral",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1281275477"
+  },
+  {
+   "id": "node/6907377691",
+   "name": "Golden Gate Diner",
+   "address": "1318 Union Boulevard, Allentown, PA",
+   "lat": 40.6245782,
+   "lng": -75.4350753,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907377691"
+  },
+  {
+   "id": "node/7681823955",
+   "name": "Good Times Pizzeria",
+   "address": "2114 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6395539,
+   "lng": -75.3988,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7681823955"
+  },
+  {
+   "id": "node/6935899815",
+   "name": "Gordon Grill",
+   "address": "429 Gordon Street, Allentown",
+   "lat": 40.60934,
+   "lng": -75.469248,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6935899815"
+  },
+  {
+   "id": "node/7928569885",
+   "name": "Gourmet Buffet & Grill",
+   "address": "3317 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5792343,
+   "lng": -75.5247841,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://foodeist.com/place/gourmetbuffet",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928569885"
+  },
+  {
+   "id": "way/1318875935",
+   "name": "Grand China Buffet & Grill",
+   "address": "2347 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6421438,
+   "lng": -75.4034646,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1318875935"
+  },
+  {
+   "id": "node/6909493820",
+   "name": "Great Wall",
+   "address": "1124 Union Boulevard, Allentown, PA",
+   "lat": 40.6243586,
+   "lng": -75.4384082,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493820"
+  },
+  {
+   "id": "way/1302652375",
+   "name": "Griddle 145",
+   "address": "1146 MacArthur Road, Whitehall, PA",
+   "lat": 40.6206675,
+   "lng": -75.4808374,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "Tu-Su 08:00-14:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1302652375"
+  },
+  {
+   "id": "way/722762251",
+   "name": "Grille 3501",
+   "address": "3501 Broadway, Allentown, PA",
+   "lat": 40.5869267,
+   "lng": -75.529849,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 706 0100",
+   "website": "https://www.grille3501.com/",
+   "openingHours": "Mo-Fr 11:30-22:00; Sa 16:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/722762251"
+  },
+  {
+   "id": "way/32856249",
+   "name": "Grove Street Pub & Grill",
+   "address": "1094 Howertown Road, North Catasauqua, PA",
+   "lat": 40.6628717,
+   "lng": -75.4724303,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-477-3305",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/32856249"
+  },
+  {
+   "id": "way/153729209",
+   "name": "Grumpy's Bar-B-Que Roadhouse",
+   "address": "3000 Mauch Chunk Road, Allentown, PA",
+   "lat": 40.6497759,
+   "lng": -75.5372495,
+   "types": [
+    "restaurant",
+    "barbecue"
+   ],
+   "cuisine": [
+    "barbecue"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107694600",
+   "website": "https://grumpysbbq.net/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/153729209"
+  },
+  {
+   "id": "way/198872807",
+   "name": "Gyro Concept",
+   "address": "",
+   "lat": 40.6453847,
+   "lng": -75.3440363,
+   "types": [
+    "restaurant",
+    "greek",
+    "mediterranean",
+    "drive_through"
+   ],
+   "cuisine": [
+    "greek",
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872807"
+  },
+  {
+   "id": "node/7685089148",
+   "name": "Haaz's",
+   "address": "3217 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6569481,
+   "lng": -75.4183074,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685089148"
+  },
+  {
+   "id": "way/576439768",
+   "name": "Hamilton Family Diner",
+   "address": "2027 Hamilton Street, Allentown, PA",
+   "lat": 40.5947626,
+   "lng": -75.5000987,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104336452",
+   "website": "https://www.hamfamallentown.com/",
+   "openingHours": "24/7",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/576439768"
+  },
+  {
+   "id": "node/12682720768",
+   "name": "HandHeldz",
+   "address": "518 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6120282,
+   "lng": -75.3712056,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720768"
+  },
+  {
+   "id": "way/846600528",
+   "name": "Hank's Italian Ice Co.",
+   "address": "303 Main Street, Emmaus, PA",
+   "lat": 40.5359597,
+   "lng": -75.4905433,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14846611901",
+   "website": "https://hanksice.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846600528"
+  },
+  {
+   "id": "node/5807665806",
+   "name": "Hanover Eatery",
+   "address": "5090 Bath Pike, Bethlehem, PA",
+   "lat": 40.681352,
+   "lng": -75.388053,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "06:00-03:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665806"
+  },
+  {
+   "id": "node/5156089177",
+   "name": "Happy Garden",
+   "address": "Whitehall",
+   "lat": 40.6550606,
+   "lng": -75.4964729,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.happygardenwhitehall.com/",
+   "openingHours": "Mo-Th 11:00-21:30; Tu off; Fr,Sa 11:00-22:30; Su 12:00-21:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5156089177"
+  },
+  {
+   "id": "node/6943158040",
+   "name": "Happy Garden",
+   "address": "501 North 7th Street, Allentown, PA",
+   "lat": 40.6093309,
+   "lng": -75.4748777,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158040"
+  },
+  {
+   "id": "node/6931245747",
+   "name": "Happy Sandwich",
+   "address": "123 South 7th Street, Allentown, PA",
+   "lat": 40.6001902,
+   "lng": -75.4705148,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6931245747"
+  },
+  {
+   "id": "node/12695556433",
+   "name": "Happy Wok",
+   "address": "4462 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6661275,
+   "lng": -75.3078647,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12695556433"
+  },
+  {
+   "id": "node/5807665763",
+   "name": "Hash & Hearth",
+   "address": "",
+   "lat": 40.6637401,
+   "lng": -75.4246031,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665763"
+  },
+  {
+   "id": "node/2797243352",
+   "name": "Hawks Nest",
+   "address": "",
+   "lat": 40.6055535,
+   "lng": -75.3761247,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2797243352"
+  },
+  {
+   "id": "way/448278954",
+   "name": "Heights Athletic Association",
+   "address": "2345 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6425654,
+   "lng": -75.350987,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/448278954"
+  },
+  {
+   "id": "way/115938538",
+   "name": "Hellertown Diner",
+   "address": "29 Main Street, Hellertown, PA",
+   "lat": 40.568192,
+   "lng": -75.3397263,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/115938538"
+  },
+  {
+   "id": "node/4802566804",
+   "name": "Henry's Salt of the Sea",
+   "address": "1926 West Allen Street, Allentown, PA",
+   "lat": 40.6032951,
+   "lng": -75.5011712,
+   "types": [
+    "restaurant",
+    "seafood"
+   ],
+   "cuisine": [
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 434-2628",
+   "website": "https://henryssaltofthesea.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4802566804"
+  },
+  {
+   "id": "node/12682720753",
+   "name": "Hi Pot",
+   "address": "312 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6119609,
+   "lng": -75.3740328,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720753"
+  },
+  {
+   "id": "node/5807665791",
+   "name": "Hibachi Grill & Supreme Buffet",
+   "address": "3811 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6733799,
+   "lng": -75.347331,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665791"
+  },
+  {
+   "id": "node/12682692090",
+   "name": "Hill to Hill Grille",
+   "address": "120 West 3rd Street, Bethlehem, PA",
+   "lat": 40.6114886,
+   "lng": -75.3813219,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682692090"
+  },
+  {
+   "id": "way/1278058417",
+   "name": "Home Town Breakfast Bar & Grill",
+   "address": "8732 Hamilton Boulevard, Breinigsville, PA",
+   "lat": 40.5389599,
+   "lng": -75.6269093,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103957316",
+   "website": "https://thehometowndiner.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278058417"
+  },
+  {
+   "id": "node/13016673094",
+   "name": "Honeygrow",
+   "address": "1872 Airport Road, Allentown, PA",
+   "lat": 40.6396593,
+   "lng": -75.4348107,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13016673094"
+  },
+  {
+   "id": "node/6943100158",
+   "name": "Hop Po",
+   "address": "647 North 7th Street, Allentown, PA",
+   "lat": 40.6117892,
+   "lng": -75.4758591,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943100158"
+  },
+  {
+   "id": "way/1432684172",
+   "name": "Hops at the Paddock",
+   "address": "1945 West Columbia Street, Allentown, PA",
+   "lat": 40.6173539,
+   "lng": -75.5084624,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104373911",
+   "website": "https://www.hopslehighvalley.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1432684172"
+  },
+  {
+   "id": "way/1346493165",
+   "name": "Hops Fogelsville Hotel",
+   "address": "7921 Main Street, Fogelsville, PA",
+   "lat": 40.5834554,
+   "lng": -75.6325125,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103953999",
+   "website": "https://www.hopslehighvalley.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1346493165"
+  },
+  {
+   "id": "node/2825660325",
+   "name": "Hot Dog Shop",
+   "address": "",
+   "lat": 40.6970992,
+   "lng": -75.5007237,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2825660325"
+  },
+  {
+   "id": "node/3610833383",
+   "name": "Hotel B Ice Cream Parlor",
+   "address": "462 Main Street, Bethlehem, PA",
+   "lat": 40.6202827,
+   "lng": -75.3818657,
+   "types": [
+    "cafe",
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.hotelbethlehem.com/hotel-b-ice-cream-parlor",
+   "openingHours": "Su-Th 10:00-21:00; Fr-Sa 10:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3610833383"
+  },
+  {
+   "id": "way/850933311",
+   "name": "House & Barn",
+   "address": "1449 Chestnut Street, Emmaus, PA",
+   "lat": 40.525994,
+   "lng": -75.5137656,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104216666",
+   "website": "https://www.houseandbarn.net/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/850933311"
+  },
+  {
+   "id": "node/13022129336",
+   "name": "Hunan Garden",
+   "address": "1224 Liberty Street, Allentown, PA",
+   "lat": 40.6058354,
+   "lng": -75.486332,
+   "types": [
+    "fast_food",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022129336"
+  },
+  {
+   "id": "node/2074694083",
+   "name": "Hunan Inn",
+   "address": "14 East Broad Street, Bethlehem, PA",
+   "lat": 40.6221896,
+   "lng": -75.3779417,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-868-8878",
+   "website": null,
+   "openingHours": "Mo-Th 11:00-22:30; Fr-Sa 11:00-23:00; Su 12:00-22:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2074694083"
+  },
+  {
+   "id": "way/1279558171",
+   "name": "Hunan Springs",
+   "address": "4939 Hamilton Boulevard, Wescosville, PA",
+   "lat": 40.5665259,
+   "lng": -75.5539227,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103668338",
+   "website": "https://hunansprings.net/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1279558171"
+  },
+  {
+   "id": "way/706081705",
+   "name": "Ice Cream World",
+   "address": "3512 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5769401,
+   "lng": -75.5271743,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104398591",
+   "website": "https://www.icecreamworld.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/706081705"
+  },
+  {
+   "id": "way/859796328",
+   "name": "ICEE Mix-it-Up",
+   "address": "",
+   "lat": 40.5791,
+   "lng": -75.5332827,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/icee-mix-it-up",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/859796328"
+  },
+  {
+   "id": "way/860890378",
+   "name": "ICEE Mix-it-Up",
+   "address": "",
+   "lat": 40.5790509,
+   "lng": -75.5284639,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/icee-mix-it-up",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860890378"
+  },
+  {
+   "id": "node/5876415699",
+   "name": "Ichiban Japanese Restaurant",
+   "address": "1914 Catasauqua Road, Allentown, PA",
+   "lat": 40.6409344,
+   "lng": -75.4288524,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5876415699"
+  },
+  {
+   "id": "node/2830722949",
+   "name": "IHOP",
+   "address": "1511 Lehigh Street, Allentown, PA",
+   "lat": 40.5796826,
+   "lng": -75.4798674,
+   "types": [
+    "restaurant",
+    "breakfast",
+    "pancake"
+   ],
+   "cuisine": [
+    "breakfast",
+    "pancake"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-797-6113",
+   "website": "https://restaurants.ihop.com/en-us/pa/allentown/breakfast-1511-lehigh-st-5500",
+   "openingHours": "Mo-Th,Su 06:00-22:00; Fr 06:00-24:00; Sa 00:00-24:00",
+   "brand": "IHOP",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2830722949"
+  },
+  {
+   "id": "node/6935899820",
+   "name": "Ikee's Corner",
+   "address": "248 North 5th Street, Allentown",
+   "lat": 40.607347,
+   "lng": -75.4699921,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6935899820"
+  },
+  {
+   "id": "node/6943158015",
+   "name": "Indian Cafe",
+   "address": "549 North 7th Street, Allentown, PA",
+   "lat": 40.6104717,
+   "lng": -75.4754284,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158015"
+  },
+  {
+   "id": "node/4378216051",
+   "name": "Iron Hill Brewery & Restaurant",
+   "address": "",
+   "lat": 40.628818,
+   "lng": -75.4815654,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4378216051"
+  },
+  {
+   "id": "node/12017167769",
+   "name": "Iron Run Beverage",
+   "address": "7525 Tilghman Street, Allentown, PA",
+   "lat": 40.5857484,
+   "lng": -75.6222771,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12017167769"
+  },
+  {
+   "id": "node/13022263281",
+   "name": "Island Bay Grill",
+   "address": "231 Tilghman Street, Allentown, PA",
+   "lat": 40.6149179,
+   "lng": -75.4654964,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022263281"
+  },
+  {
+   "id": "node/367966614",
+   "name": "J's Subs",
+   "address": "1830",
+   "lat": 40.6881768,
+   "lng": -75.498219,
+   "types": [
+    "fast_food",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/367966614"
+  },
+  {
+   "id": "node/5807665783",
+   "name": "Jack's Brick Oven Pizza And Restaurant",
+   "address": "",
+   "lat": 40.688904,
+   "lng": -75.3373319,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665783"
+  },
+  {
+   "id": "node/6923701397",
+   "name": "Jack's Pizza",
+   "address": "155 Tilghman Street, Allentown, PA",
+   "lat": 40.6157637,
+   "lng": -75.4627667,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6923701397"
+  },
+  {
+   "id": "node/10088688012",
+   "name": "Jamba",
+   "address": "4606 Broadway, Allentown, PA",
+   "lat": 40.5859983,
+   "lng": -75.5588171,
+   "types": [
+    "fast_food",
+    "juice",
+    "takeaway"
+   ],
+   "cuisine": [
+    "juice"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-351-5101",
+   "website": "https://locations.jamba.com/pa/allentown/4606-broadway",
+   "openingHours": "Mo-Sa 08:30-20:30; Su 08:30-20:00",
+   "brand": "Jamba",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10088688012"
+  },
+  {
+   "id": "node/6215093534",
+   "name": "Jasmine Restaurant",
+   "address": "701 East 4th Street, Bethlehem, PA",
+   "lat": 40.6108049,
+   "lng": -75.3692336,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6215093534"
+  },
+  {
+   "id": "node/5800087109",
+   "name": "Java Joint",
+   "address": "",
+   "lat": 40.6525191,
+   "lng": -75.435371,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087109"
+  },
+  {
+   "id": "way/1276732351",
+   "name": "Java Joint Drive Thru",
+   "address": "7370 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.549749,
+   "lng": -75.5997293,
+   "types": [
+    "cafe",
+    "coffee_shop"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16105303171",
+   "website": "https://javajointdrivethru.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1276732351"
+  },
+  {
+   "id": "node/6077547646",
+   "name": "Jersey Mike's Subs",
+   "address": "7150 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.549997,
+   "lng": -75.5944289,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-841-0373",
+   "website": "https://www.jerseymikes.com/8020/trexlertown-pa",
+   "openingHours": "10:00-21:00",
+   "brand": "Jersey Mike's Subs",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6077547646"
+  },
+  {
+   "id": "node/10088688014",
+   "name": "Jersey Mike's Subs",
+   "address": "4670 Broadway, Allentown, PA",
+   "lat": 40.5882032,
+   "lng": -75.5610824,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": "https://www.jerseymikes.com/8040/allentown-pa",
+   "openingHours": null,
+   "brand": "Jersey Mike's Subs",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10088688014"
+  },
+  {
+   "id": "node/12709754713",
+   "name": "Jersey Mike's Subs",
+   "address": "2415 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6424947,
+   "lng": -75.4037582,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Jersey Mike's Subs",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12709754713"
+  },
+  {
+   "id": "node/13030682113",
+   "name": "Jersey Mike's Subs",
+   "address": "1862 Leithsville Road, Hellertown, PA",
+   "lat": 40.5631529,
+   "lng": -75.3406262,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Jersey Mike's Subs",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13030682113"
+  },
+  {
+   "id": "way/882841612",
+   "name": "Jersey Mike's Subs",
+   "address": "2618 MacArthur Road, Whitehall, PA",
+   "lat": 40.6458011,
+   "lng": -75.4945367,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": "https://www.jerseymikes.com/8043/whitehall-pa",
+   "openingHours": null,
+   "brand": "Jersey Mike's Subs",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/882841612"
+  },
+  {
+   "id": "node/8023571736",
+   "name": "Joe Cool's Soda Pop Shop",
+   "address": "",
+   "lat": 40.5798367,
+   "lng": -75.5319313,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/joe-cools-soda-pop-shop",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8023571736"
+  },
+  {
+   "id": "node/831649306",
+   "name": "Joe's Tavern",
+   "address": "12 West Broad Street, Bethlehem, PA",
+   "lat": 40.6224409,
+   "lng": -75.3789133,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [
+    "pub"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-868-3200",
+   "website": "https://www.joestavern.com/",
+   "openingHours": "Mo-Sa 09:00-02:00; Su 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649306"
+  },
+  {
+   "id": "node/6344037673",
+   "name": "Johnnie Lustig's Frankfurters",
+   "address": "835 North New Street, Bethlehem, PA",
+   "lat": 40.6260975,
+   "lng": -75.3785112,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6344037673"
+  },
+  {
+   "id": "node/3924684305",
+   "name": "Johnny's Bagel & Deli",
+   "address": "472 Main Street, Bethlehem, PA",
+   "lat": 40.620477,
+   "lng": -75.3818568,
+   "types": [
+    "cafe",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-861-8299",
+   "website": "http://johnnysbagelsanddeli.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3924684305"
+  },
+  {
+   "id": "node/4205745216",
+   "name": "Johnny's Bagels & Deli",
+   "address": "6 Farrington Square, Bethlehem, PA",
+   "lat": 40.6094243,
+   "lng": -75.3785273,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4205745216"
+  },
+  {
+   "id": "node/885761695",
+   "name": "Jumbars",
+   "address": "1342 Chelsea Avenue, Bethlehem, PA",
+   "lat": 40.6320941,
+   "lng": -75.3767212,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/885761695"
+  },
+  {
+   "id": "node/259501643",
+   "name": "Just Chill Creamery",
+   "address": "5503 Macarthur Road, Whitehall, PA",
+   "lat": 40.6849081,
+   "lng": -75.5211938,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104400179",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/259501643"
+  },
+  {
+   "id": "node/11522544976",
+   "name": "Kasey Lynn’s on Broadway",
+   "address": "1305 Broadway, Fountain Hill, PA",
+   "lat": 40.6005012,
+   "lng": -75.3992874,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108492260",
+   "website": "https://www.facebook.com/kaseysonbroadway/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11522544976"
+  },
+  {
+   "id": "way/223898265",
+   "name": "Kathy's Country Kitchen",
+   "address": "",
+   "lat": 40.4726284,
+   "lng": -75.370615,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/223898265"
+  },
+  {
+   "id": "way/655238202",
+   "name": "Katie's Country Kitchen",
+   "address": "4804 PA 309, Schnecksville, PA",
+   "lat": 40.6721517,
+   "lng": -75.6118978,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-760-3200",
+   "website": "https://katiescountrykitchen.com/",
+   "openingHours": "06:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/655238202"
+  },
+  {
+   "id": "way/198872032",
+   "name": "Keystone Pub & Grill",
+   "address": "3529 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6536304,
+   "lng": -75.3354042,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-814-0400",
+   "website": "https://keystonepub.com/",
+   "openingHours": "Mo-Th,Su 11:00-24:00, Fr-Sa 11:00-02:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872032"
+  },
+  {
+   "id": "node/3564584495",
+   "name": "KFC",
+   "address": "2571 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6452713,
+   "lng": -75.3464964,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://locations.kfc.com/pa/bethlehem/2571-easton-avenue",
+   "openingHours": null,
+   "brand": "KFC",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3564584495"
+  },
+  {
+   "id": "way/154238311",
+   "name": "KFC",
+   "address": "1612 Macarthur Road, Whitehall, PA",
+   "lat": 40.629717,
+   "lng": -75.4852961,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-776-7773",
+   "website": "https://locations.kfc.com/pa/whitehall/1612-macarthur-road",
+   "openingHours": null,
+   "brand": "KFC",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/154238311"
+  },
+  {
+   "id": "way/266642221",
+   "name": "KFC",
+   "address": "7150 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5499476,
+   "lng": -75.5966417,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-7350",
+   "website": "https://locations.kfc.com/pa/trexlertown/7150-hamilton-blvd",
+   "openingHours": "10:30-21:00",
+   "brand": "KFC",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266642221"
+  },
+  {
+   "id": "way/610929640",
+   "name": "KFC",
+   "address": "1833 South 4th Street, Allentown, PA",
+   "lat": 40.581728,
+   "lng": -75.4563513,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16107913666",
+   "website": "https://locations.kfc.com/pa/allentown/1833-s-4th-street",
+   "openingHours": null,
+   "brand": "KFC",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610929640"
+  },
+  {
+   "id": "way/666301652",
+   "name": "KFC",
+   "address": "2184 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6266657,
+   "lng": -75.4199545,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16108676880",
+   "website": "https://locations.kfc.com/pa/bethlehem/2184-w-union-blvd",
+   "openingHours": null,
+   "brand": "KFC",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/666301652"
+  },
+  {
+   "id": "way/608136972",
+   "name": "Kim's Kitchen",
+   "address": "5842 Main Street, Center Valley, PA",
+   "lat": 40.5309161,
+   "lng": -75.3991546,
+   "types": [
+    "restaurant",
+    "korean"
+   ],
+   "cuisine": [
+    "korean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102825857",
+   "website": "http://www.kimskitchen309.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/608136972"
+  },
+  {
+   "id": "node/6923695277",
+   "name": "Kina's",
+   "address": "602 North Front Street, Allentown, PA",
+   "lat": 40.6149329,
+   "lng": -75.459831,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6923695277"
+  },
+  {
+   "id": "way/1306098430",
+   "name": "King Kone & the Jungle Kafe",
+   "address": "4128 Spring Mill Road, Whitehall, PA",
+   "lat": 40.6849921,
+   "lng": -75.5225798,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102611935",
+   "website": "http://www.kingkonewhitehall.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1306098430"
+  },
+  {
+   "id": "node/12683556838",
+   "name": "King Wing",
+   "address": "129 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6121414,
+   "lng": -75.3762628,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12683556838"
+  },
+  {
+   "id": "node/11893016948",
+   "name": "King's Pizza",
+   "address": "7751 Glenlivet Drive West, Fogelsville, PA",
+   "lat": 40.5907315,
+   "lng": -75.6305504,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11893016948"
+  },
+  {
+   "id": "way/198873021",
+   "name": "Kingfish American Bistro & Wine Bar",
+   "address": "",
+   "lat": 40.6429599,
+   "lng": -75.3205857,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198873021"
+  },
+  {
+   "id": "node/11216893663",
+   "name": "Kinoa",
+   "address": "518 West Broad Street, Bethlehem, PA",
+   "lat": 40.6226176,
+   "lng": -75.3904318,
+   "types": [
+    "restaurant",
+    "peruvian",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "peruvian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 0091",
+   "website": "https://www.kinoaperuvianrestaurant.com/",
+   "openingHours": "Tu-Th 11:00-19:00; Fr, Sa 11:00-20:00; Su 12:00-19:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11216893663"
+  },
+  {
+   "id": "node/13016674806",
+   "name": "Kinya Ramen",
+   "address": "925 Airport Center Road, Allentown, PA",
+   "lat": 40.6403074,
+   "lng": -75.4380799,
+   "types": [
+    "restaurant",
+    "ramen"
+   ],
+   "cuisine": [
+    "ramen"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13016674806"
+  },
+  {
+   "id": "node/5678995201",
+   "name": "Komé",
+   "address": "",
+   "lat": 40.5600442,
+   "lng": -75.4096886,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5678995201"
+  },
+  {
+   "id": "node/12682720733",
+   "name": "Kuki Restaurant",
+   "address": "118 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6117099,
+   "lng": -75.376475,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720733"
+  },
+  {
+   "id": "node/6338848538",
+   "name": "Kumo Sushi",
+   "address": "825 Linden Street, Bethlehem, PA",
+   "lat": 40.625761,
+   "lng": -75.3706179,
+   "types": [
+    "restaurant",
+    "sushi"
+   ],
+   "cuisine": [
+    "sushi"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338848538"
+  },
+  {
+   "id": "node/9756023596",
+   "name": "Kung Fu II",
+   "address": "4402 Birkland Place, Easton, PA",
+   "lat": 40.6560452,
+   "lng": -75.2855132,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9756023596"
+  },
+  {
+   "id": "node/6909493853",
+   "name": "La Bicicleta Arepa Bar",
+   "address": "709 Union Boulevard, Allentown, PA",
+   "lat": 40.6243299,
+   "lng": -75.4475161,
+   "types": [
+    "restaurant",
+    "venezuelan"
+   ],
+   "cuisine": [
+    "venezuelan"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493853"
+  },
+  {
+   "id": "node/13022865783",
+   "name": "La Bodega",
+   "address": "233 Hamilton Street, Allentown, PA",
+   "lat": 40.6056884,
+   "lng": -75.4612818,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022865783"
+  },
+  {
+   "id": "way/488131213",
+   "name": "La Borgata Pizzeria",
+   "address": "3570 Lanark Road, Lanark, PA",
+   "lat": 40.5519296,
+   "lng": -75.434096,
+   "types": [
+    "restaurant",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/488131213"
+  },
+  {
+   "id": "node/6943228787",
+   "name": "La Casa del Chimi II",
+   "address": "147 North 7th Street, Allentown",
+   "lat": 40.6049897,
+   "lng": -75.4728167,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943228787"
+  },
+  {
+   "id": "way/1411647598",
+   "name": "La Casera",
+   "address": "954 Pembroke Road, Bethlehem, PA",
+   "lat": 40.6290823,
+   "lng": -75.3480696,
+   "types": [
+    "restaurant",
+    "latin"
+   ],
+   "cuisine": [
+    "latin"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1411647598"
+  },
+  {
+   "id": "node/13115837720",
+   "name": "La Cocina de Abuelo",
+   "address": "634 Hamilton Street, Allentown, PA",
+   "lat": 40.6026645,
+   "lng": -75.4706061,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13115837720"
+  },
+  {
+   "id": "node/6907377732",
+   "name": "La Esquina De Jorge",
+   "address": "624 North Maxwell Street, Allentown, PA",
+   "lat": 40.619174,
+   "lng": -75.4355473,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907377732"
+  },
+  {
+   "id": "way/1273969101",
+   "name": "La Herencia El Camacho",
+   "address": "7 Lehigh Street, Catasauqua, PA",
+   "lat": 40.648465,
+   "lng": -75.4682485,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16106348928",
+   "website": "https://laherenciaelcamachocatasauqua.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1273969101"
+  },
+  {
+   "id": "node/6935122975",
+   "name": "La Isla",
+   "address": "46 North 10th Street, Allentown",
+   "lat": 40.6017986,
+   "lng": -75.4786532,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6935122975"
+  },
+  {
+   "id": "node/13061217884",
+   "name": "La Kasita Gustosa",
+   "address": "645 Cleveland Street, Allentown, PA",
+   "lat": 40.5937297,
+   "lng": -75.4657017,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061217884"
+  },
+  {
+   "id": "node/1339057457",
+   "name": "La Lupita",
+   "address": "4 West 4th Street, Bethlehem, PA",
+   "lat": 40.6103219,
+   "lng": -75.3786375,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1339057457"
+  },
+  {
+   "id": "node/13022264214",
+   "name": "La Placita",
+   "address": "158 North 12th Street, Allentown, PA",
+   "lat": 40.6021547,
+   "lng": -75.4831624,
+   "types": [
+    "fast_food",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022264214"
+  },
+  {
+   "id": "node/13061217826",
+   "name": "La Poblanita Deli",
+   "address": "767 Saint John Street, Allentown, PA",
+   "lat": 40.5917141,
+   "lng": -75.4689154,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061217826"
+  },
+  {
+   "id": "node/11905054604",
+   "name": "Las Brasa's",
+   "address": "704 Emaus Avenue, Allentown, PA",
+   "lat": 40.5740868,
+   "lng": -75.4604336,
+   "types": [
+    "restaurant",
+    "peruvian"
+   ],
+   "cuisine": [
+    "peruvian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905054604"
+  },
+  {
+   "id": "node/6943186645",
+   "name": "Las Orquideas Colombian Bakery & Restaurant",
+   "address": "426 North 7th Street, Allentown, PA",
+   "lat": 40.6083624,
+   "lng": -75.4747871,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943186645"
+  },
+  {
+   "id": "node/6935188640",
+   "name": "Las Palmas",
+   "address": "",
+   "lat": 40.6035504,
+   "lng": -75.4789044,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6935188640"
+  },
+  {
+   "id": "way/1355129509",
+   "name": "Laurys Station American Diner",
+   "address": "5470 PA 145, Laurys Station, PA",
+   "lat": 40.723974,
+   "lng": -75.5313137,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102611911",
+   "website": "https://www.facebook.com/laurysstationamericangrill/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1355129509"
+  },
+  {
+   "id": "node/11905435305",
+   "name": "LaZeez Fresh Mediterranean Grill",
+   "address": "4666 Broadway, Allentown, PA",
+   "lat": 40.5880824,
+   "lng": -75.5611184,
+   "types": [
+    "restaurant",
+    "mediterranean"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905435305"
+  },
+  {
+   "id": "way/1356805247",
+   "name": "Leather Corner Post Bar & Grille",
+   "address": "6855 Horseshoe Road, Orefield, PA",
+   "lat": 40.6212093,
+   "lng": -75.6386398,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-395-1782",
+   "website": null,
+   "openingHours": "Tu-Th 15:00-23:00; Fr-Sa 12:00-25:30, Su 13:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1356805247"
+  },
+  {
+   "id": "node/7975349682",
+   "name": "Lee's Hoagie House",
+   "address": "",
+   "lat": 40.5497931,
+   "lng": -75.4914852,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7975349682"
+  },
+  {
+   "id": "node/7937971888",
+   "name": "Lehigh Cafe",
+   "address": "",
+   "lat": 40.5276822,
+   "lng": -75.5097021,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971888"
+  },
+  {
+   "id": "way/43000993",
+   "name": "Lehigh Pizza",
+   "address": "13 West 3rd Street, Bethlehem, PA",
+   "lat": 40.6121256,
+   "lng": -75.3791717,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/43000993"
+  },
+  {
+   "id": "node/6943186639",
+   "name": "Liberty Lunch",
+   "address": "450 North 7th Street, Allentown, PA",
+   "lat": 40.6090702,
+   "lng": -75.4751259,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943186639"
+  },
+  {
+   "id": "way/826312920",
+   "name": "Lily Sushi",
+   "address": "1908 Walbert Avenue, Allentown, PA",
+   "lat": 40.6160256,
+   "lng": -75.5067523,
+   "types": [
+    "restaurant",
+    "asian",
+    "sushi",
+    "japanese"
+   ],
+   "cuisine": [
+    "asian",
+    "sushi",
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.lilysushigrillallentown.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/826312920"
+  },
+  {
+   "id": "way/1351810683",
+   "name": "Limeport Family Restaurant",
+   "address": "1463 Limeport Pike, Limeport, PA",
+   "lat": 40.5090952,
+   "lng": -75.447749,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14842325506",
+   "website": "https://www.limeportfamilyrestaurant.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1351810683"
+  },
+  {
+   "id": "way/1358969668",
+   "name": "Limeport Inn",
+   "address": "1505 Limeport Pike, Coopersburg, PA",
+   "lat": 40.5078017,
+   "lng": -75.4469276,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109671810",
+   "website": "https://limeportinn.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1358969668"
+  },
+  {
+   "id": "node/6080721241",
+   "name": "Lin's Garden",
+   "address": "339 Chestnut Street, Emmaus, PA",
+   "lat": 40.5352407,
+   "lng": -75.4914321,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 965 9300",
+   "website": null,
+   "openingHours": "Mo-Th 11:00-21:30,Fr-Sa 11:00-22:30,Su 14:30-21:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6080721241"
+  },
+  {
+   "id": "node/7937971898",
+   "name": "Ling Nan",
+   "address": "1328 Chestnut Street, Emmaus, PA",
+   "lat": 40.5266925,
+   "lng": -75.5094103,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971898"
+  },
+  {
+   "id": "way/440520210",
+   "name": "Linx Restaurant and Pub",
+   "address": "3712 West Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5756129,
+   "lng": -75.5298011,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/440520210"
+  },
+  {
+   "id": "way/846600526",
+   "name": "Liscenced 2 Grill",
+   "address": "332 Main Street, Emmaus, PA",
+   "lat": 40.5350083,
+   "lng": -75.4907496,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846600526"
+  },
+  {
+   "id": "node/5675639653",
+   "name": "Lit Roastery and Bakeshop",
+   "address": "26 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6118746,
+   "lng": -75.377676,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484 626 0945",
+   "website": null,
+   "openingHours": "Tu-Fr 07:00-19:00; Sa 09:00-17:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5675639653"
+  },
+  {
+   "id": "node/993745810",
+   "name": "Little Caesars",
+   "address": "1517 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6334776,
+   "lng": -75.367299,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://littlecaesars.com/en-us/store/8451/",
+   "openingHours": null,
+   "brand": "Little Caesars",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/993745810"
+  },
+  {
+   "id": "node/6907375382",
+   "name": "Little Caesars",
+   "address": "1636 Union Boulevard, Allentown, PA",
+   "lat": 40.6249539,
+   "lng": -75.4315426,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://littlecaesars.com/en-us/store/9592/",
+   "openingHours": null,
+   "brand": "Little Caesars",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907375382"
+  },
+  {
+   "id": "node/11905018575",
+   "name": "Little Caesars",
+   "address": "1439 Allen Street, Allentown, PA",
+   "lat": 40.606585,
+   "lng": -75.4916737,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Little Caesars",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905018575"
+  },
+  {
+   "id": "node/5800087364",
+   "name": "Liu's House",
+   "address": "4128 Tilghman Street, Allentown",
+   "lat": 40.5914027,
+   "lng": -75.5485412,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.liushouseallentown.com/",
+   "openingHours": "Mo-Th 11:00-21:00; Fr,Sa 11:00-22:00; Su 12:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087364"
+  },
+  {
+   "id": "node/12686424320",
+   "name": "LJ's Midnight Munchies",
+   "address": "748 East 4th Street, Bethlehem, PA",
+   "lat": 40.6106439,
+   "lng": -75.3676419,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12686424320"
+  },
+  {
+   "id": "way/94395435",
+   "name": "LongHorn Steakhouse",
+   "address": "1035 Grape Street, Whitehall, PA",
+   "lat": 40.6344974,
+   "lng": -75.4792923,
+   "types": [
+    "restaurant",
+    "steak_house"
+   ],
+   "cuisine": [
+    "steak_house"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102318829",
+   "website": "https://www.longhornsteakhouse.com/locations/pa/whitehall/whitehall/5372",
+   "openingHours": "Fr-Sa 11:00-23:00; Su-Th 11:00-22:00",
+   "brand": "LongHorn Steakhouse",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/94395435"
+  },
+  {
+   "id": "way/1240224051",
+   "name": "Lorenzo's Pizza",
+   "address": "1402 Broadway, Fountain Hill, PA",
+   "lat": 40.5997434,
+   "lng": -75.4004527,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.lorenzospizzamenu.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1240224051"
+  },
+  {
+   "id": "node/8720008602",
+   "name": "Lost Tavern",
+   "address": "444 Main Street, Bethlehem, PA",
+   "lat": 40.6198548,
+   "lng": -75.3818804,
+   "types": [
+    "pub",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484 851 3980",
+   "website": "https://www.losttavernbrewing.com/",
+   "openingHours": "Tu-Th 15:00-20:00; Fr 15:00-21:00; Sa 12:00-21:00; Su 10:00-18:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8720008602"
+  },
+  {
+   "id": "node/6909493833",
+   "name": "Love’s Restaurant & Lounge",
+   "address": "1019 Union Boulevard, Allentown, PA",
+   "lat": 40.6245216,
+   "lng": -75.4408325,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493833"
+  },
+  {
+   "id": "node/4886201644",
+   "name": "Lu Taqueria",
+   "address": "559 Main Street, Bethlehem, PA",
+   "lat": 40.62201,
+   "lng": -75.3827249,
+   "types": [
+    "restaurant",
+    "mexican",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 0600",
+   "website": "https://www.lutaqueriapa.com/",
+   "openingHours": "Mo-Th 14:00-22:00; Fr-Sa 14:00-24:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4886201644"
+  },
+  {
+   "id": "way/1510784552",
+   "name": "Lumpy Lou's Bar & Grill",
+   "address": "212 South 15th Street, Allentown, PA",
+   "lat": 40.5947722,
+   "lng": -75.4868943,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104331290",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1510784552"
+  },
+  {
+   "id": "node/6338872243",
+   "name": "Mach's Gute",
+   "address": "713 Linden Street, Bethlehem, PA",
+   "lat": 40.6239509,
+   "lng": -75.3706757,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338872243"
+  },
+  {
+   "id": "node/6209304782",
+   "name": "Machu Picchu Peruvian Restaurant",
+   "address": "1330 East 4th Street, Bethlehem, PA",
+   "lat": 40.6113951,
+   "lng": -75.3549742,
+   "types": [
+    "restaurant",
+    "peruvian"
+   ],
+   "cuisine": [
+    "peruvian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6209304782"
+  },
+  {
+   "id": "way/1180366925",
+   "name": "Mack Truck Stop",
+   "address": "789 East 1st Street, Bethlehem, PA",
+   "lat": 40.6147842,
+   "lng": -75.3686872,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1180366925"
+  },
+  {
+   "id": "way/1273236247",
+   "name": "Macungie Diner",
+   "address": "202 East Main Street, Macungie, PA",
+   "lat": 40.5135011,
+   "lng": -75.5517546,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104218333",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1273236247"
+  },
+  {
+   "id": "way/1280409818",
+   "name": "Mad Dogs Hot Dogs & Sugar Shack",
+   "address": "17 North Poplar Street, Macungie, PA",
+   "lat": 40.5143707,
+   "lng": -75.5512536,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-519-1313",
+   "website": "https://maddogssugarshack.com",
+   "openingHours": "We-Sa 08:00-20:00; Su 12:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1280409818"
+  },
+  {
+   "id": "way/1278681631",
+   "name": "Madeline's",
+   "address": "1250 Turnstone Drive, Fogelsville, PA",
+   "lat": 40.5893469,
+   "lng": -75.6312836,
+   "types": [
+    "restaurant",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14842772250",
+   "website": "https://madelinesfogelsville.com",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278681631"
+  },
+  {
+   "id": "node/6904305368",
+   "name": "Mahoney's",
+   "address": "1609 Hanover Avenue, Allentown, PA",
+   "lat": 40.6198299,
+   "lng": -75.4314962,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904305368"
+  },
+  {
+   "id": "node/367983924",
+   "name": "Main Street Family Restaurant & Diner",
+   "address": "2023 Main Street, Northampton, PA",
+   "lat": 40.6902713,
+   "lng": -75.4990124,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1-610-262-2822",
+   "website": "https://www.mainstreetfamily.restaurant/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/367983924"
+  },
+  {
+   "id": "node/6923695280",
+   "name": "Maly's Cafe",
+   "address": "",
+   "lat": 40.6155527,
+   "lng": -75.4601024,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6923695280"
+  },
+  {
+   "id": "node/6909493827",
+   "name": "Mama Juana Restaurant",
+   "address": "1038 Union Boulevard, Allentown, PA",
+   "lat": 40.6241542,
+   "lng": -75.4396498,
+   "types": [
+    "restaurant",
+    "indian"
+   ],
+   "cuisine": [
+    "indian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493827"
+  },
+  {
+   "id": "node/831649245",
+   "name": "Mama Nina's Foccacheria",
+   "address": "546 Main Street, Bethlehem, PA",
+   "lat": 40.6216019,
+   "lng": -75.3818469,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649245"
+  },
+  {
+   "id": "node/13033549304",
+   "name": "Mama's Famous Pizza and Grill",
+   "address": "1901 Hamilton Street, Allentown, PA",
+   "lat": 40.5956685,
+   "lng": -75.4972955,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033549304"
+  },
+  {
+   "id": "node/6545606464",
+   "name": "Mama’s Italian Grill",
+   "address": "1044 Trexlertown Road, Breinigsville, PA",
+   "lat": 40.5510906,
+   "lng": -75.6074606,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108419577",
+   "website": "https://www.mamasitaliangrill.net/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6545606464"
+  },
+  {
+   "id": "node/13060097091",
+   "name": "Mama's Pizza",
+   "address": "655 Main Street, Slatington, PA",
+   "lat": 40.750839,
+   "lng": -75.6126313,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107679441",
+   "website": "https://mamaspizzaslatington.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13060097091"
+  },
+  {
+   "id": "way/856536530",
+   "name": "Mamma Mia Piazeria",
+   "address": "2917 West Emaus Avenue, Allentown, PA",
+   "lat": 40.5586944,
+   "lng": -75.4808444,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107970600",
+   "website": "https://www.ordermammamiapizzeria.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/856536530"
+  },
+  {
+   "id": "node/6909493812",
+   "name": "Mangu Latin Restaurant",
+   "address": "1139 Union Boulevard, Allentown, PA",
+   "lat": 40.6248793,
+   "lng": -75.4373938,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493812"
+  },
+  {
+   "id": "node/2779166046",
+   "name": "Manhattan Bagel",
+   "address": "3221 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6571071,
+   "lng": -75.4184548,
+   "types": [
+    "fast_food",
+    "bagel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "bagel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Manhattan Bagel",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2779166046"
+  },
+  {
+   "id": "node/5821469619",
+   "name": "Manhattan Bagel",
+   "address": "3100 Tilghman Street, Allentown, PA",
+   "lat": 40.5968872,
+   "lng": -75.5246387,
+   "types": [
+    "fast_food",
+    "bagel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "bagel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Manhattan Bagel",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469619"
+  },
+  {
+   "id": "way/610929628",
+   "name": "Manhattan Bagel",
+   "address": "402 West Emaus Avenue, Allentown, PA",
+   "lat": 40.5773682,
+   "lng": -75.4543243,
+   "types": [
+    "fast_food",
+    "bagel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "bagel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-797-0887",
+   "website": "https://locations.dunkindonuts.com/en/pa/allentown/402-w-emaus-ave/302014",
+   "openingHours": "Mo-Sa 05:00-19:00; Su 05:00-18:00",
+   "brand": "Manhattan Bagel",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610929628"
+  },
+  {
+   "id": "way/262965030",
+   "name": "Manhattan Grill & Deli",
+   "address": "4440 Easton Avenue, Bethlehem, PA",
+   "lat": 40.666104,
+   "lng": -75.3083209,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/262965030"
+  },
+  {
+   "id": "node/12064426214",
+   "name": "Manuel Chimi Restaurant",
+   "address": "1234 MacArthur Road, Whitehall, PA",
+   "lat": 40.6225795,
+   "lng": -75.4818201,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12064426214"
+  },
+  {
+   "id": "node/6914168873",
+   "name": "Mar & Tierra Restaurant",
+   "address": "760 Hanover Avenue, Allentown, PA",
+   "lat": 40.6160853,
+   "lng": -75.4431941,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6914168873"
+  },
+  {
+   "id": "way/1302652377",
+   "name": "Maraschino Diner",
+   "address": "1162 MacArthur Road, Whitehall, PA",
+   "lat": 40.6211181,
+   "lng": -75.4810181,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1302652377"
+  },
+  {
+   "id": "way/348781823",
+   "name": "Marblehead Chowder House",
+   "address": "",
+   "lat": 40.6697805,
+   "lng": -75.2727523,
+   "types": [
+    "restaurant",
+    "seafood"
+   ],
+   "cuisine": [
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/348781823"
+  },
+  {
+   "id": "way/278142376",
+   "name": "Mario's Pizza",
+   "address": "",
+   "lat": 40.6769082,
+   "lng": -75.4869658,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278142376"
+  },
+  {
+   "id": "node/5800087090",
+   "name": "Mario's Pizza Cafe",
+   "address": "",
+   "lat": 40.5816468,
+   "lng": -75.388585,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087090"
+  },
+  {
+   "id": "node/7928569890",
+   "name": "Mario's Pizza Cafe",
+   "address": "3335 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5790593,
+   "lng": -75.5252495,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-268-5036",
+   "website": "https://www.mariosallentown.com/",
+   "openingHours": "Mo off; Tu-Th 10:00-21:00; Fr,Sa 10:00-22:00; Su 11:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928569890"
+  },
+  {
+   "id": "node/259500711",
+   "name": "Mario's Pizzeria",
+   "address": "",
+   "lat": 40.6768891,
+   "lng": -75.487016,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/259500711"
+  },
+  {
+   "id": "node/993739560",
+   "name": "Martelucci's Pizza",
+   "address": "1419 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6323973,
+   "lng": -75.3682804,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/993739560"
+  },
+  {
+   "id": "node/6982908555",
+   "name": "Maza Middle Eastern",
+   "address": "2449 Mickley Avenue, Whitehall, PA",
+   "lat": 40.6433768,
+   "lng": -75.4903379,
+   "types": [
+    "restaurant",
+    "middle_eastern"
+   ],
+   "cuisine": [
+    "middle_eastern"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6982908555"
+  },
+  {
+   "id": "way/1433800071",
+   "name": "Maza Middle Eastern Cuisine",
+   "address": "2449 Mickley Avenue, Whitehall, PA",
+   "lat": 40.643436,
+   "lng": -75.4902331,
+   "types": [
+    "restaurant",
+    "middle_eastern"
+   ],
+   "cuisine": [
+    "middle_eastern"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1433800071"
+  },
+  {
+   "id": "way/1444418333",
+   "name": "McCall Collective Brewery & Restaurant",
+   "address": "102 East Susquehanna Street, Allentown, PA",
+   "lat": 40.5905645,
+   "lng": -75.4505451,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.mccallcollectivebrewing.com/susquehanna",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1444418333"
+  },
+  {
+   "id": "node/4885851951",
+   "name": "McCarthy's Red Stag Pub",
+   "address": "534 Main Street, Bethlehem, PA",
+   "lat": 40.6213552,
+   "lng": -75.3815566,
+   "types": [
+    "pub",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-861-7631",
+   "website": "https://redstagpub.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4885851951"
+  },
+  {
+   "id": "node/6907377690",
+   "name": "McDonald's",
+   "address": "1321 Union Boulevard, Allentown, PA",
+   "lat": 40.6250627,
+   "lng": -75.4354508,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.mcdonalds.com/us/en-us/location/pa/allentown/1321-union-blvd/124.html",
+   "openingHours": null,
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907377690"
+  },
+  {
+   "id": "node/7871698070",
+   "name": "McDonald's",
+   "address": "1414 Tilghman Street, Allentown, PA",
+   "lat": 40.6072948,
+   "lng": -75.4916163,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-770-1748",
+   "website": "https://www.mcdonalds.com/us/en-us/location/5901.html",
+   "openingHours": "05:00-01:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7871698070"
+  },
+  {
+   "id": "node/12709754719",
+   "name": "McDonald's",
+   "address": "2441 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6439876,
+   "lng": -75.4049192,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12709754719"
+  },
+  {
+   "id": "way/30385805",
+   "name": "McDonald's",
+   "address": "442 Wyandotte Street, Bethlehem, PA",
+   "lat": 40.6091326,
+   "lng": -75.3855639,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-691-2033",
+   "website": "https://www.mcdonalds.com/us/en-us/location/23510.html",
+   "openingHours": "06:00-22:30",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/30385805"
+  },
+  {
+   "id": "way/94395441",
+   "name": "McDonald's",
+   "address": "2137 Macarthur Road, Whitehall, PA",
+   "lat": 40.6361284,
+   "lng": -75.48713,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-437-6929",
+   "website": "https://www.mcdonalds.com/us/en-us/location/883.html",
+   "openingHours": "06:00-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/94395441"
+  },
+  {
+   "id": "way/153924909",
+   "name": "McDonald's",
+   "address": "721 Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.5985616,
+   "lng": -75.5276309,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-439-0511",
+   "website": "https://www.mcdonalds.com/us/en-us/location/626.html",
+   "openingHours": "05:30-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/153924909"
+  },
+  {
+   "id": "way/198872819",
+   "name": "McDonald's",
+   "address": "2610 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6438873,
+   "lng": -75.3460012,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-865-1421",
+   "website": "https://www.mcdonalds.com/us/en-us/location/16849.html",
+   "openingHours": "05:30-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872819"
+  },
+  {
+   "id": "way/204137465",
+   "name": "McDonald's",
+   "address": "3925 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6756807,
+   "lng": -75.3447764,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-849-2426",
+   "website": "https://www.mcdonalds.com/us/en-us/location/5640.html",
+   "openingHours": "05:30-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/204137465"
+  },
+  {
+   "id": "way/266642283",
+   "name": "McDonald's",
+   "address": "6896 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.551288,
+   "lng": -75.5939212,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-398-2218",
+   "website": "https://www.mcdonalds.com/us/en-us/location/5225.html",
+   "openingHours": "07:00-21:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266642283"
+  },
+  {
+   "id": "way/278761360",
+   "name": "McDonald's",
+   "address": "3020 Lehigh Street, Allentown, PA",
+   "lat": 40.5597562,
+   "lng": -75.4877872,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-797-4150",
+   "website": "https://www.mcdonalds.com/us/en-us/location/61.html",
+   "openingHours": "06:00-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278761360"
+  },
+  {
+   "id": "way/346669436",
+   "name": "McDonald's",
+   "address": "14 South Main Street, Hellertown, PA",
+   "lat": 40.5672526,
+   "lng": -75.34017,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-838-7578",
+   "website": "https://www.mcdonalds.com/us/en-us/location/6219.html",
+   "openingHours": "Mo-Th 07:00-20:00; Fr-Su 07:00-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/346669436"
+  },
+  {
+   "id": "way/440521584",
+   "name": "McDonald's",
+   "address": "3860 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5745548,
+   "lng": -75.5327834,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-770-8996",
+   "website": "https://www.mcdonalds.com/us/en-us/location/21675.html",
+   "openingHours": "06:00-22:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/440521584"
+  },
+  {
+   "id": "way/441624108",
+   "name": "McDonald's",
+   "address": "5060 State Highway 873, Schnecksville, PA",
+   "lat": 40.6781608,
+   "lng": -75.6142985,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-799-0531",
+   "website": "https://www.mcdonalds.com/us/en-us/location/17688.html",
+   "openingHours": "05:30-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/441624108"
+  },
+  {
+   "id": "way/536526249",
+   "name": "McDonald's",
+   "address": "473 Main Street, Walnutport, PA",
+   "lat": 40.7574448,
+   "lng": -75.5944657,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-767-1490",
+   "website": "https://www.mcdonalds.com/us/en-us/location/5723.html",
+   "openingHours": "Mo-Th 05:30-22:00; Fr-Sa 05:30-23:00; Su 05:30-22:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/536526249"
+  },
+  {
+   "id": "way/610929643",
+   "name": "McDonald's",
+   "address": "1432 South 4th Street, Allentown, PA",
+   "lat": 40.5860568,
+   "lng": -75.4604987,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-797-3010",
+   "website": "https://www.mcdonalds.com/us/en-us/location/4434.html",
+   "openingHours": "05:00-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610929643"
+  },
+  {
+   "id": "way/667760392",
+   "name": "McDonald's",
+   "address": "2998 MacArthur Road, Whitehall, PA",
+   "lat": 40.6506681,
+   "lng": -75.5011025,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-437-7817",
+   "website": "https://www.mcdonalds.com/us/en-us/location/37871.html",
+   "openingHours": "06:00-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/667760392"
+  },
+  {
+   "id": "way/846603330",
+   "name": "McDonald's",
+   "address": "1101 Chestnut Street, Emmaus, PA",
+   "lat": 40.5290166,
+   "lng": -75.5066322,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-967-3306",
+   "website": "https://www.mcdonalds.com/us/en-us/location/4625.html",
+   "openingHours": "06:00-23:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846603330"
+  },
+  {
+   "id": "way/1206760186",
+   "name": "McDonald's",
+   "address": "6690 Short Drive, Coopersburg, PA",
+   "lat": 40.5221127,
+   "lng": -75.3886132,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 215-804-8160",
+   "website": "https://www.mcdonalds.com/us/en-us/location/39717.html",
+   "openingHours": "Mo-Sa 05:00-20:00; Su 06:00-19:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1206760186"
+  },
+  {
+   "id": "way/1267125622",
+   "name": "McDonald's",
+   "address": "6479 Village Lane, Macungie, PA",
+   "lat": 40.5202891,
+   "lng": -75.5696922,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-965-9686",
+   "website": "https://www.mcdonalds.com/us/en-us/location/27057.html",
+   "openingHours": "Mo-Su 06:00-22:00",
+   "brand": "McDonald's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1267125622"
+  },
+  {
+   "id": "node/11077932955",
+   "name": "Mediterranean Café & Grill",
+   "address": "7720 Main Street, Fogelsville, PA",
+   "lat": 40.5827663,
+   "lng": -75.6278965,
+   "types": [
+    "restaurant",
+    "mediterranean",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-391-0400",
+   "website": "https://medicafegrill.com/",
+   "openingHours": "Mo-Sa 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11077932955"
+  },
+  {
+   "id": "node/13114267897",
+   "name": "Mediterranean Grill",
+   "address": "22 West Broad Street, Bethlehem, PA",
+   "lat": 40.6224481,
+   "lng": -75.3791761,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13114267897"
+  },
+  {
+   "id": "way/384115319",
+   "name": "Melt",
+   "address": "",
+   "lat": 40.5595108,
+   "lng": -75.4099956,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/384115319"
+  },
+  {
+   "id": "node/6314874445",
+   "name": "Menchie's",
+   "address": "3014 Linden Street, Bethlehem, PA",
+   "lat": 40.6569608,
+   "lng": -75.3550634,
+   "types": [
+    "ice_cream",
+    "frozen_yogurt"
+   ],
+   "cuisine": [
+    "frozen_yogurt"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Menchie's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6314874445"
+  },
+  {
+   "id": "node/7928570051",
+   "name": "Menchie's",
+   "address": "353 South Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.5831755,
+   "lng": -75.5206961,
+   "types": [
+    "ice_cream",
+    "frozen_yogurt"
+   ],
+   "cuisine": [
+    "frozen_yogurt"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Menchie's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928570051"
+  },
+  {
+   "id": "node/8931201682",
+   "name": "Menchie's",
+   "address": "943 Airport Center Drive, Allentown, PA",
+   "lat": 40.6403452,
+   "lng": -75.4363696,
+   "types": [
+    "ice_cream",
+    "frozen_yogurt"
+   ],
+   "cuisine": [
+    "frozen_yogurt"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Menchie's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8931201682"
+  },
+  {
+   "id": "way/855665761",
+   "name": "Mercantile Club",
+   "address": "427 Railroad Street, Emmaus, PA",
+   "lat": 40.534183,
+   "lng": -75.4924036,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109653871",
+   "website": "http://themercantileclub.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/855665761"
+  },
+  {
+   "id": "node/6212134082",
+   "name": "Merengue Latín Restaurant",
+   "address": "805 East 4th Street, Bethlehem, PA",
+   "lat": 40.6108468,
+   "lng": -75.3676345,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6212134082"
+  },
+  {
+   "id": "way/1274768104",
+   "name": "Metro & John's Cafe",
+   "address": "1616 Main Street, Catasauqua, PA",
+   "lat": 40.6660827,
+   "lng": -75.4811799,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102648059",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1274768104"
+  },
+  {
+   "id": "node/6225481114",
+   "name": "Mexico Lindo",
+   "address": "720 Main Street, Bethlehem, PA",
+   "lat": 40.6242839,
+   "lng": -75.3817279,
+   "types": [
+    "restaurant",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 691 5141",
+   "website": null,
+   "openingHours": "Su-Th 11:00-20:00; Fr-Sa 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6225481114"
+  },
+  {
+   "id": "node/7685089157",
+   "name": "Mi Chong's",
+   "address": "3350 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6593003,
+   "lng": -75.4186696,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685089157"
+  },
+  {
+   "id": "node/7685098573",
+   "name": "Mi Chong's Kitchen",
+   "address": "3100 Tilghman Street, Allentown, PA",
+   "lat": 40.5971551,
+   "lng": -75.5268223,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685098573"
+  },
+  {
+   "id": "node/13022255723",
+   "name": "Mikey’s Caribbean Restaurant & Bar",
+   "address": "438 North 8th Street, Allentown, PA",
+   "lat": 40.6083862,
+   "lng": -75.4769497,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022255723"
+  },
+  {
+   "id": "node/13022848683",
+   "name": "Mildred's Soulfood",
+   "address": "309 North 2nd Street, Allentown, PA",
+   "lat": 40.6100638,
+   "lng": -75.4617725,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022848683"
+  },
+  {
+   "id": "way/965431604",
+   "name": "Miller's Ale House",
+   "address": "913 Airport Center Drive, Allentown, PA",
+   "lat": 40.64012,
+   "lng": -75.4389061,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-235-2511",
+   "website": "https://millersalehouse.com/locations/allentown/",
+   "openingHours": "Mo-We 11:00-24:00; Th-Sa 11:00-01:00, Su 11:00-24:00",
+   "brand": "Miller's Ale House",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/965431604"
+  },
+  {
+   "id": "way/53692070",
+   "name": "Miller's Diner",
+   "address": "1205",
+   "lat": 40.6798235,
+   "lng": -75.4902169,
+   "types": [
+    "restaurant",
+    "diner"
+   ],
+   "cuisine": [
+    "diner"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/53692070"
+  },
+  {
+   "id": "node/6311941164",
+   "name": "Mis Raices Restaurant & Bakery",
+   "address": "2915 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6490897,
+   "lng": -75.4103733,
+   "types": [
+    "restaurant",
+    "colombian"
+   ],
+   "cuisine": [
+    "colombian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6311941164"
+  },
+  {
+   "id": "way/94395422",
+   "name": "Mission BBQ",
+   "address": "1415 Grape Street, Whitehall, PA",
+   "lat": 40.6330868,
+   "lng": -75.4843752,
+   "types": [
+    "restaurant",
+    "barbecue"
+   ],
+   "cuisine": [
+    "barbecue"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14844080325",
+   "website": "https://mission-bbq.com/",
+   "openingHours": null,
+   "brand": "Mission BBQ",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/94395422"
+  },
+  {
+   "id": "node/12682720766",
+   "name": "Mister Lee's Noodles Bethlehem",
+   "address": "512 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6120254,
+   "lng": -75.3714703,
+   "types": [
+    "restaurant",
+    "ramen"
+   ],
+   "cuisine": [
+    "ramen"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720766"
+  },
+  {
+   "id": "node/5807665796",
+   "name": "Mitzi's Table",
+   "address": "",
+   "lat": 40.6706672,
+   "lng": -75.3462274,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665796"
+  },
+  {
+   "id": "node/13025819363",
+   "name": "Mixx at Wind Creek",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6156999,
+   "lng": -75.3600062,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819363"
+  },
+  {
+   "id": "node/4326270194",
+   "name": "Mizu Sushi & Hibachi",
+   "address": "4624 Broadway, Allentown, PA",
+   "lat": 40.5862956,
+   "lng": -75.559432,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4326270194"
+  },
+  {
+   "id": "node/13025819355",
+   "name": "Mo' Burger",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145497,
+   "lng": -75.3583716,
+   "types": [
+    "fast_food",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819355"
+  },
+  {
+   "id": "node/13759064097",
+   "name": "Mo's Eatery",
+   "address": "806 Hamilton Street, Allentown, PA",
+   "lat": 40.6014969,
+   "lng": -75.47383,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13759064097"
+  },
+  {
+   "id": "node/4033114037",
+   "name": "MOD Pizza",
+   "address": "1878 Airport Road, Allentown, PA",
+   "lat": 40.6398289,
+   "lng": -75.4346421,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-488-3800",
+   "website": "https://locations.modpizza.com/usa/pa/allentown/1878-airport-rd",
+   "openingHours": "Mo-Th 10:30-22:00; Fr-Sa 10:30-23:00; Su 10:30-22:00",
+   "brand": "MOD Pizza",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4033114037"
+  },
+  {
+   "id": "node/5929427926",
+   "name": "MOD Pizza",
+   "address": "4763 Freemansburg Avenue, Easton, PA",
+   "lat": 40.6512322,
+   "lng": -75.2950197,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-935-0006",
+   "website": "https://modpizza.com/locations/madison-farms/",
+   "openingHours": "Su-Th 10:30-22:00; Fr-Sa 10:30-23:00",
+   "brand": "MOD Pizza",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5929427926"
+  },
+  {
+   "id": "node/6311987066",
+   "name": "Moe's Southwest Grill",
+   "address": "3211 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6567059,
+   "lng": -75.4180757,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-443-1450",
+   "website": "https://locations.moes.com/pa/bethlehem/3211-schoenersville-road",
+   "openingHours": "Mo-Sa 11:00-21:00; Su 11:00-20:00",
+   "brand": "Moe's Southwest Grill",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6311987066"
+  },
+  {
+   "id": "node/10088688011",
+   "name": "Moe's Southwest Grill",
+   "address": "4604 Broadway, Allentown, PA",
+   "lat": 40.5857529,
+   "lng": -75.5589679,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-351-3402",
+   "website": "https://locations.moes.com/pa/allentown/4604-broadway",
+   "openingHours": "Mo-Sa 11:00-20:30; Su 11:00-20:00",
+   "brand": "Moe's Southwest Grill",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10088688011"
+  },
+  {
+   "id": "node/13025819352",
+   "name": "Moe's Southwest Grill",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145465,
+   "lng": -75.3585382,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Moe's Southwest Grill",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819352"
+  },
+  {
+   "id": "node/671546359",
+   "name": "Molly's Irish Grille and Sports Pub",
+   "address": "4 East 4th Street, Bethlehem, PA",
+   "lat": 40.6103478,
+   "lng": -75.3781456,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/671546359"
+  },
+  {
+   "id": "node/13025819362",
+   "name": "Molten Lounge",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6153128,
+   "lng": -75.3570921,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819362"
+  },
+  {
+   "id": "node/12971775263",
+   "name": "Munchies Grill",
+   "address": "1130 Pembroke Road, Bethlehem, PA",
+   "lat": 40.6287418,
+   "lng": -75.3537818,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12971775263"
+  },
+  {
+   "id": "node/2768592995",
+   "name": "My Place pizza",
+   "address": "",
+   "lat": 40.7273584,
+   "lng": -75.3879279,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2768592995"
+  },
+  {
+   "id": "way/207801194",
+   "name": "My Tequila House",
+   "address": "1808 MacArthur Road, Whitehall, PA",
+   "lat": 40.6312907,
+   "lng": -75.4860403,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484 664 7109",
+   "website": "https://mytequilahouse.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/207801194"
+  },
+  {
+   "id": "way/1390242243",
+   "name": "My Tequila House",
+   "address": "4558 Crackersport Road, Allentown, PA",
+   "lat": 40.6020642,
+   "lng": -75.5617569,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14843503868",
+   "website": "https://mytequilahouse.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1390242243"
+  },
+  {
+   "id": "node/11905054601",
+   "name": "Nan King",
+   "address": "704 Emaus Avenue, Allentown, PA",
+   "lat": 40.5740201,
+   "lng": -75.4605989,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905054601"
+  },
+  {
+   "id": "node/677131265",
+   "name": "Nawab Indian Restaurant",
+   "address": "13",
+   "lat": 40.6105681,
+   "lng": -75.3776973,
+   "types": [
+    "restaurant",
+    "indian"
+   ],
+   "cuisine": [
+    "indian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/677131265"
+  },
+  {
+   "id": "node/13033926688",
+   "name": "New China",
+   "address": "501 2nd Street, Catasauqua, PA",
+   "lat": 40.6545521,
+   "lng": -75.4736408,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102668000",
+   "website": "https://www.newchinacatasauqua.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033926688"
+  },
+  {
+   "id": "node/4946409935",
+   "name": "New China Buffet",
+   "address": "1658 South 4th Street, Allentown, PA",
+   "lat": 40.583566,
+   "lng": -75.4602882,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4946409935"
+  },
+  {
+   "id": "way/31019636",
+   "name": "New City View Diner",
+   "address": "1831 Macarthur Road",
+   "lat": 40.6320737,
+   "lng": -75.4853006,
+   "types": [
+    "restaurant",
+    "diner"
+   ],
+   "cuisine": [
+    "diner"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/31019636"
+  },
+  {
+   "id": "way/1286691027",
+   "name": "New Smithville Diner",
+   "address": "2277 Golden Key Road, Kutztown, PA",
+   "lat": 40.5816031,
+   "lng": -75.7073956,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1286691027"
+  },
+  {
+   "id": "node/6933338770",
+   "name": "New Star",
+   "address": "33 Main Street, Hellertown, PA",
+   "lat": 40.5684014,
+   "lng": -75.3394287,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6933338770"
+  },
+  {
+   "id": "node/6344062266",
+   "name": "New Street Pub",
+   "address": "728 North New Street, Bethlehem, PA",
+   "lat": 40.6244328,
+   "lng": -75.3781603,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6344062266"
+  },
+  {
+   "id": "node/6943158031",
+   "name": "New York Gyro",
+   "address": "513 North 7th Street, Allentown, PA",
+   "lat": 40.6096338,
+   "lng": -75.4750317,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158031"
+  },
+  {
+   "id": "node/11611461256",
+   "name": "Newburg Inn",
+   "address": "",
+   "lat": 40.7030994,
+   "lng": -75.3297801,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11611461256"
+  },
+  {
+   "id": "node/6344037679",
+   "name": "Nick's Pizza",
+   "address": "822 Main Street, Bethlehem, PA",
+   "lat": 40.6257952,
+   "lng": -75.3816238,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6344037679"
+  },
+  {
+   "id": "node/6935219406",
+   "name": "Nikita's",
+   "address": "712 Turner Street, Allentown, PA",
+   "lat": 40.6047952,
+   "lng": -75.4735044,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6935219406"
+  },
+  {
+   "id": "node/5157595395",
+   "name": "Nini Tea",
+   "address": "2241 MacArthur Road, Whitehall, PA",
+   "lat": 40.6391507,
+   "lng": -75.4887598,
+   "types": [
+    "cafe",
+    "bubble_tea"
+   ],
+   "cuisine": [
+    "bubble_tea"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5157595395"
+  },
+  {
+   "id": "node/11904728868",
+   "name": "No. 1 Chinese Restaurant",
+   "address": "3703 PA 378, Bethlehem, PA",
+   "lat": 40.5864233,
+   "lng": -75.3846881,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11904728868"
+  },
+  {
+   "id": "way/1352756277",
+   "name": "Norma J's",
+   "address": "2717 PA 309, Orefield, PA",
+   "lat": 40.6314315,
+   "lng": -75.5824847,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103953664",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1352756277"
+  },
+  {
+   "id": "node/13127916360",
+   "name": "NOT Just Bagels",
+   "address": "5585 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5615751,
+   "lng": -75.5659108,
+   "types": [
+    "fast_food",
+    "bagel"
+   ],
+   "cuisine": [
+    "bagel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13127916360"
+  },
+  {
+   "id": "way/1273135781",
+   "name": "Notch Modern Kitchen & Bar",
+   "address": "5036 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5653305,
+   "lng": -75.5554357,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108414610",
+   "website": "https://notchmknb.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1273135781"
+  },
+  {
+   "id": "way/504487178",
+   "name": "Nova Restaurant & Lounge",
+   "address": "1869 South 4th Street, Allentown, PA",
+   "lat": 40.5804114,
+   "lng": -75.4556207,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/504487178"
+  },
+  {
+   "id": "way/561131666",
+   "name": "Noval Kitchen",
+   "address": "2342 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6419118,
+   "lng": -75.3510288,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/561131666"
+  },
+  {
+   "id": "way/1417997571",
+   "name": "Nowhere Coffee Co: West End",
+   "address": "",
+   "lat": 40.598253,
+   "lng": -75.5270124,
+   "types": [
+    "cafe",
+    "coffee_shop"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1417997571"
+  },
+  {
+   "id": "node/12682692094",
+   "name": "NYC Village Pizza",
+   "address": "129 West 4th Street, Bethlehem, PA",
+   "lat": 40.6105116,
+   "lng": -75.3810227,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682692094"
+  },
+  {
+   "id": "way/860890380",
+   "name": "Oasis",
+   "address": "",
+   "lat": 40.57795,
+   "lng": -75.530713,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/oasis",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860890380"
+  },
+  {
+   "id": "way/488132093",
+   "name": "Old belmont Inne",
+   "address": "",
+   "lat": 40.5901622,
+   "lng": -75.3884083,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/488132093"
+  },
+  {
+   "id": "way/553867189",
+   "name": "Old Brewery Tavern",
+   "address": "138 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6253456,
+   "lng": -75.3832758,
+   "types": [
+    "bar",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 691 9406",
+   "website": "http://www.oldbrewerytavern.com/",
+   "openingHours": "Tu-Su 015:00-02:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/553867189"
+  },
+  {
+   "id": "way/30762479",
+   "name": "Old Country Buffet",
+   "address": "",
+   "lat": 40.6343497,
+   "lng": -75.4834638,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Old Country Buffet",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/30762479"
+  },
+  {
+   "id": "way/232724169",
+   "name": "Old Fashined Funnel Cake",
+   "address": "",
+   "lat": 40.5789161,
+   "lng": -75.5315208,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/old-fashioned-funnel-cake",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/232724169"
+  },
+  {
+   "id": "way/1354020119",
+   "name": "Old Post Inn",
+   "address": "3337 Old Post Road, Slatington, PA",
+   "lat": 40.7236645,
+   "lng": -75.6150392,
+   "types": [
+    "bar",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107675612",
+   "website": "https://www.facebook.com/OldPostInn/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1354020119"
+  },
+  {
+   "id": "node/6206301359",
+   "name": "Olive Branch",
+   "address": "355 Broadway, Bethlehem, PA",
+   "lat": 40.609384,
+   "lng": -75.3844907,
+   "types": [
+    "restaurant",
+    "middle_eastern"
+   ],
+   "cuisine": [
+    "middle_eastern"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6206301359"
+  },
+  {
+   "id": "way/296374279",
+   "name": "On The Border",
+   "address": "",
+   "lat": 40.6393791,
+   "lng": -75.4414884,
+   "types": [
+    "restaurant",
+    "tex-mex"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "On The Border",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/296374279"
+  },
+  {
+   "id": "node/6314874442",
+   "name": "One Third",
+   "address": "3022 Linden Street, Bethlehem, PA",
+   "lat": 40.6571457,
+   "lng": -75.3549546,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6314874442"
+  },
+  {
+   "id": "node/7152454624",
+   "name": "Orizaba",
+   "address": "614 West Broad Street, Bethlehem, PA",
+   "lat": 40.6226427,
+   "lng": -75.3915669,
+   "types": [
+    "restaurant",
+    "mexican",
+    "latin_american"
+   ],
+   "cuisine": [
+    "mexican",
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484 893 4467",
+   "website": "https://www.orizababethlehem.com/",
+   "openingHours": "Mo-Fr 11:00-21:00; Sa 11:00-22:00; Su 15:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7152454624"
+  },
+  {
+   "id": "way/217668520",
+   "name": "Outback Steakhouse",
+   "address": "3200 Emrick Boulevard, Bethlehem, PA",
+   "lat": 40.666306,
+   "lng": -75.2947066,
+   "types": [
+    "restaurant",
+    "american",
+    "steak",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "american",
+    "steak"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-814-5860",
+   "website": "https://locations.outback.com/pennsylvania/bethlehem/3200-emrick-boulevard",
+   "openingHours": "Mo-Th 11:00-21:30; Fr-Sa 11:00-22:00; Su 11:00-21:00",
+   "brand": "Outback Steakhouse",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/217668520"
+  },
+  {
+   "id": "way/1279561213",
+   "name": "Outback Steakhouse",
+   "address": "800 North Krocks Road, Allentown, PA",
+   "lat": 40.5632593,
+   "lng": -75.5634189,
+   "types": [
+    "restaurant",
+    "american",
+    "steak",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "american",
+    "steak"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-437-7117",
+   "website": "https://locations.outback.com/pennsylvania/allentown/800-n-krocks-road",
+   "openingHours": "Mo-Th 11:00-21:30; Fr-Sa 11:00-22:30; Su 11:00-21:00",
+   "brand": "Outback Steakhouse",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1279561213"
+  },
+  {
+   "id": "way/1389199274",
+   "name": "P.J. Whelihan's",
+   "address": "1658 Hausman Road, Allentown, PA",
+   "lat": 40.6105911,
+   "lng": -75.5693737,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103954077",
+   "website": "https://locations.pjspub.com/pa/allentown/1658-hausman-road",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1389199274"
+  },
+  {
+   "id": "way/1387655570",
+   "name": "P.J. Whelihan's Pub",
+   "address": "4595 Broadway, Allentown, PA",
+   "lat": 40.5883374,
+   "lng": -75.5571299,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103952532",
+   "website": "https://locations.pjspub.com/pa/allentown/4595-broadway",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1387655570"
+  },
+  {
+   "id": "way/148905633",
+   "name": "P.J. Whelihan's Pub + Restaurant",
+   "address": "3395 High Point Boulevard, Bethlehem, PA",
+   "lat": 40.6577759,
+   "lng": -75.4164162,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/148905633"
+  },
+  {
+   "id": "way/115938576",
+   "name": "PA House",
+   "address": "662 Front Street, Hellertown, PA",
+   "lat": 40.5788686,
+   "lng": -75.3429135,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14848516662",
+   "website": "https://www.thepahouse.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/115938576"
+  },
+  {
+   "id": "node/5800087108",
+   "name": "PA Pub Café & Spirits",
+   "address": "",
+   "lat": 40.6526454,
+   "lng": -75.435106,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087108"
+  },
+  {
+   "id": "node/6590078708",
+   "name": "Pagan's Place",
+   "address": "701 North Jordan Street, Allentown, PA",
+   "lat": 40.614034,
+   "lng": -75.4687631,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6590078708"
+  },
+  {
+   "id": "node/5156089175",
+   "name": "Palace Pizza & Sports Bar",
+   "address": "3690 Lehigh Street, Whitehall",
+   "lat": 40.6548018,
+   "lng": -75.4966933,
+   "types": [
+    "restaurant",
+    "pizza",
+    "italian"
+   ],
+   "cuisine": [
+    "pizza",
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5156089175"
+  },
+  {
+   "id": "way/198872044",
+   "name": "Palace Restaurant",
+   "address": "",
+   "lat": 40.6531114,
+   "lng": -75.3352438,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872044"
+  },
+  {
+   "id": "node/12692225874",
+   "name": "Palace Sports Bar",
+   "address": "",
+   "lat": 40.6547085,
+   "lng": -75.4966678,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12692225874"
+  },
+  {
+   "id": "way/71279633",
+   "name": "Palermo's Pizzeria",
+   "address": "11",
+   "lat": 40.6969936,
+   "lng": -75.4980413,
+   "types": [
+    "restaurant",
+    "italian",
+    "ice_cream"
+   ],
+   "cuisine": [
+    "italian",
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/71279633"
+  },
+  {
+   "id": "node/12983007961",
+   "name": "Palette & Pour",
+   "address": "101 Founder's Way, Bethlehem, PA",
+   "lat": 40.6141018,
+   "lng": -75.3673164,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12983007961"
+  },
+  {
+   "id": "node/11684849346",
+   "name": "Palumbo Pizza & Subs",
+   "address": "1531 Lehigh Street, Allentown, PA",
+   "lat": 40.5793859,
+   "lng": -75.4793174,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11684849346"
+  },
+  {
+   "id": "node/11077932954",
+   "name": "Panda & Fish",
+   "address": "7720 Main Street, Fogelsville, PA",
+   "lat": 40.5826891,
+   "lng": -75.627869,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11077932954"
+  },
+  {
+   "id": "node/7995785032",
+   "name": "Panera Bread",
+   "address": "3100 West Tilghman Street, Allentown, PA",
+   "lat": 40.5970754,
+   "lng": -75.5245668,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "bakery",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich",
+    "bakery"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-432-3221",
+   "website": "https://locations.panerabread.com/pa/allentown/3100-w-tilghman-st.html",
+   "openingHours": "Mo-Sa 07:00-21:00; Su 08:00-21:00",
+   "brand": "Panera Bread",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7995785032"
+  },
+  {
+   "id": "node/8376043202",
+   "name": "Panera Bread",
+   "address": "6379 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5568296,
+   "lng": -75.5816852,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "bakery",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich",
+    "bakery"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-398-0565",
+   "website": "https://locations.panerabread.com/pa/allentown/6379-hamilton-blvd.html",
+   "openingHours": "07:00-21:00",
+   "brand": "Panera Bread",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8376043202"
+  },
+  {
+   "id": "node/8931201675",
+   "name": "Panera Bread",
+   "address": "915 Airport Center Drive, Allentown, PA",
+   "lat": 40.640283,
+   "lng": -75.4385232,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "bakery",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich",
+    "bakery"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-266-0756",
+   "website": "https://locations.panerabread.com/pa/allentown/915-airport-center-dr.html",
+   "openingHours": "Mo-Fr 08:00-21:00; Sa 09:00-21:00; Su 09:00-20:00",
+   "brand": "Panera Bread",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8931201675"
+  },
+  {
+   "id": "way/79290980",
+   "name": "Panera Bread",
+   "address": "2669 MacArthur Road, Whitehall, PA",
+   "lat": 40.6454544,
+   "lng": -75.492686,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "bakery",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich",
+    "bakery"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-433-8101",
+   "website": "https://locations.panerabread.com/pa/whitehall/2669-macarthur-rd.html",
+   "openingHours": "07:00-21:00",
+   "brand": "Panera Bread",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/79290980"
+  },
+  {
+   "id": "way/225871971",
+   "name": "Panera Bread",
+   "address": "4442 Southmont Way, Easton, PA",
+   "lat": 40.6545149,
+   "lng": -75.2861233,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "bakery",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich",
+    "bakery"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-253-4340",
+   "website": "https://locations.panerabread.com/pa/easton/4442-southmont-way.html",
+   "openingHours": "Mo-Th 07:00-21:00; Fr-Sa 06:00-21:00; Su 07:00-21:00",
+   "brand": "Panera Bread",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/225871971"
+  },
+  {
+   "id": "way/295034999",
+   "name": "Panera Bread",
+   "address": "3301 Bath Pike, Bethlehem, PA",
+   "lat": 40.6609481,
+   "lng": -75.3821406,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "bakery",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich",
+    "bakery"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-866-9802",
+   "website": "https://locations.panerabread.com/pa/bethlehem/3301-bath-pike.html",
+   "openingHours": "07:00-21:00",
+   "brand": "Panera Bread",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/295034999"
+  },
+  {
+   "id": "node/5821469664",
+   "name": "Papa John's",
+   "address": "1042 Mill Creek Road, Allentown, PA",
+   "lat": 40.553253,
+   "lng": -75.5820449,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-530-7272",
+   "website": "https://locations.papajohns.com/united-states/pa/18106/allentown/1042-mill-creek-road",
+   "openingHours": "Mo-Th 10:30-23:00; Fr-Sa 10:30-23:45; Su 10:30-23:00",
+   "brand": "Papa John's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469664"
+  },
+  {
+   "id": "node/13229662104",
+   "name": "Papa John's",
+   "address": "1236 Main Street, Hellertown, PA",
+   "lat": 40.5873191,
+   "lng": -75.3413372,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16108387272",
+   "website": "https://locations.papajohns.com/united-states/pa/18055/hellertown/1236-main-street",
+   "openingHours": null,
+   "brand": "Papa John's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13229662104"
+  },
+  {
+   "id": "way/531116920",
+   "name": "Papa John's",
+   "address": "2531 MacArthur Road, Whitehall, PA",
+   "lat": 40.6439044,
+   "lng": -75.4915639,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-437-7272",
+   "website": "https://locations.papajohns.com/united-states/pa/18052/whitehall/2531-macarthur-road",
+   "openingHours": "Mo-Th 10:30-23:00; Fr-Sa 10:30-24:00; Su 10:30-23:00",
+   "brand": "Papa John's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531116920"
+  },
+  {
+   "id": "way/1213632925",
+   "name": "Papa John's",
+   "address": "1401 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6321072,
+   "lng": -75.3687439,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Papa John's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1213632925"
+  },
+  {
+   "id": "way/262966925",
+   "name": "Papa Luigi's",
+   "address": "",
+   "lat": 40.5794318,
+   "lng": -75.5287637,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/papa-luigis",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/262966925"
+  },
+  {
+   "id": "way/846625227",
+   "name": "Papa Rossi's Pizzaria",
+   "address": "3851 Main Road East, Emmaus, PA",
+   "lat": 40.5059271,
+   "lng": -75.4962961,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109679770",
+   "website": "https://www.paparossispizza.net/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846625227"
+  },
+  {
+   "id": "node/13229662089",
+   "name": "Paprikas",
+   "address": "",
+   "lat": 40.5866535,
+   "lng": -75.3415393,
+   "types": [
+    "restaurant",
+    "hungarian"
+   ],
+   "cuisine": [
+    "hungarian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108386570",
+   "website": "https://hungarianpaprikas.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13229662089"
+  },
+  {
+   "id": "node/7685098574",
+   "name": "Parma Pizza",
+   "address": "3100 Tilghman Street, Allentown, PA",
+   "lat": 40.5972162,
+   "lng": -75.5267687,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685098574"
+  },
+  {
+   "id": "node/6212035015",
+   "name": "Parrillon Dos",
+   "address": "1041 East 4th Street, Bethlehem, PA",
+   "lat": 40.6110947,
+   "lng": -75.3630152,
+   "types": [
+    "restaurant",
+    "dominican",
+    "latin_american"
+   ],
+   "cuisine": [
+    "dominican",
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6212035015"
+  },
+  {
+   "id": "way/658000819",
+   "name": "Pat's Pizza & Bistro",
+   "address": "1426 West Broad Street, Bethlehem, PA",
+   "lat": 40.6230681,
+   "lng": -75.4028829,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 8100",
+   "website": "https://www.patsbistro.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/658000819"
+  },
+  {
+   "id": "node/11711418063",
+   "name": "Peking Chinese",
+   "address": "",
+   "lat": 40.5484071,
+   "lng": -75.5977127,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11711418063"
+  },
+  {
+   "id": "node/7899179339",
+   "name": "Penn Pizza",
+   "address": "",
+   "lat": 40.5656689,
+   "lng": -75.5168629,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7899179339"
+  },
+  {
+   "id": "node/9870510761",
+   "name": "Pennsville Tavern & Stagecoach Stop",
+   "address": "3750 Lehigh Drive, Northampton, PA",
+   "lat": 40.7488871,
+   "lng": -75.5046026,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9870510761"
+  },
+  {
+   "id": "node/506657678",
+   "name": "Perkins",
+   "address": "3940 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.6774214,
+   "lng": -75.3422696,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Perkins",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/506657678"
+  },
+  {
+   "id": "way/30385826",
+   "name": "Perkins",
+   "address": "205 West 3rd Street, Bethlehem",
+   "lat": 40.6122364,
+   "lng": -75.3823896,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Perkins",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/30385826"
+  },
+  {
+   "id": "way/440521108",
+   "name": "Perkins",
+   "address": "3214 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5792407,
+   "lng": -75.5219869,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108205767",
+   "website": "https://www.perkinsrestaurants.com/locations/us/pa/allentown/3214-hamilton-blvd/",
+   "openingHours": null,
+   "brand": "Perkins",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/440521108"
+  },
+  {
+   "id": "way/970149185",
+   "name": "Perkins",
+   "address": "3400 Lehigh Street, Allentown, PA",
+   "lat": 40.5527049,
+   "lng": -75.4918946,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109655241",
+   "website": "https://www.perkinsrestaurants.com/locations/us/pa/allentown/3400-lehigh-street/",
+   "openingHours": null,
+   "brand": "Perkins",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/970149185"
+  },
+  {
+   "id": "node/8210322224",
+   "name": "Philly Pretzel Factory",
+   "address": "2411 MacArthur Road, Whitehall, PA",
+   "lat": 40.6425279,
+   "lng": -75.4901409,
+   "types": [
+    "fast_food",
+    "pretzel",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pretzel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Philly Pretzel Factory",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8210322224"
+  },
+  {
+   "id": "node/4317500124",
+   "name": "Pho Bowl",
+   "address": "524 West Broad Street, Bethlehem, PA",
+   "lat": 40.6226119,
+   "lng": -75.3905935,
+   "types": [
+    "restaurant",
+    "vietnamese",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 4484",
+   "website": null,
+   "openingHours": "Tu-Sa 11:00-21:00; Su 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4317500124"
+  },
+  {
+   "id": "node/6943186641",
+   "name": "Pho Le",
+   "address": "446 North 7th Street, Allentown, PA",
+   "lat": 40.6089727,
+   "lng": -75.4750881,
+   "types": [
+    "restaurant",
+    "vietnamese"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943186641"
+  },
+  {
+   "id": "node/6238108286",
+   "name": "Pho Viet Royal",
+   "address": "2126 West Union Boulevard, Bethlehem, PA",
+   "lat": 40.6290632,
+   "lng": -75.4189796,
+   "types": [
+    "restaurant",
+    "vietnamese"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6238108286"
+  },
+  {
+   "id": "node/6219855055",
+   "name": "Pho Viet Royal II",
+   "address": "1880 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6377147,
+   "lng": -75.3486863,
+   "types": [
+    "restaurant",
+    "vietnamese"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6219855055"
+  },
+  {
+   "id": "node/13019394368",
+   "name": "Pho-Nom1nal",
+   "address": "319 South Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.5831343,
+   "lng": -75.5216387,
+   "types": [
+    "restaurant",
+    "vietnamese"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019394368"
+  },
+  {
+   "id": "node/6907377699",
+   "name": "Pho's #!",
+   "address": "1500 Union Boulevard, Allentown, PA",
+   "lat": 40.6247193,
+   "lng": -75.4336387,
+   "types": [
+    "restaurant",
+    "vietnamese"
+   ],
+   "cuisine": [
+    "vietnamese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907377699"
+  },
+  {
+   "id": "node/5876415695",
+   "name": "Picasso Pizza III",
+   "address": "1860 Catasauqua Road, Allentown, PA",
+   "lat": 40.6393829,
+   "lng": -75.4299839,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5876415695"
+  },
+  {
+   "id": "node/11711418066",
+   "name": "Picasso's Pizza",
+   "address": "",
+   "lat": 40.5495489,
+   "lng": -75.5979729,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11711418066"
+  },
+  {
+   "id": "node/7685089159",
+   "name": "Pinoy Kitchen & Grill",
+   "address": "3350 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6594597,
+   "lng": -75.4188444,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685089159"
+  },
+  {
+   "id": "way/1434290180",
+   "name": "Pints & Pies Pub",
+   "address": "21 East Elizabeth Avenue, Bethlehem, PA",
+   "lat": 40.6311477,
+   "lng": -75.3771559,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1434290180"
+  },
+  {
+   "id": "node/13180473115",
+   "name": "Pizza Chef",
+   "address": "4011 William Penn Highway, Easton, PA",
+   "lat": 40.6703461,
+   "lng": -75.2710181,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13180473115"
+  },
+  {
+   "id": "node/2740429306",
+   "name": "Pizza Como",
+   "address": "2626 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6443169,
+   "lng": -75.3457893,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2740429306"
+  },
+  {
+   "id": "node/993745813",
+   "name": "Pizza Hut",
+   "address": "1314 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6305959,
+   "lng": -75.3694972,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-974-9675",
+   "website": "https://locations.pizzahut.com/pa/bethlehem/1314-easton-ave",
+   "openingHours": null,
+   "brand": "Pizza Hut",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/993745813"
+  },
+  {
+   "id": "node/5157429402",
+   "name": "Pizza Hut",
+   "address": "2417 MacArthur Road, Whitehall, PA",
+   "lat": 40.6425605,
+   "lng": -75.4902109,
+   "types": [
+    "restaurant",
+    "pizza",
+    "delivery"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-602-9050",
+   "website": "https://locations.pizzahut.com/pa/whitehall/2417-macarthur-road",
+   "openingHours": "Mo-Th,Su 10:00-23:00; Fr-Sa 10:00-24:00",
+   "brand": "Pizza Hut",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5157429402"
+  },
+  {
+   "id": "node/7928567584",
+   "name": "Pizza Hut",
+   "address": "3315 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5792194,
+   "lng": -75.5245773,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-395-1200",
+   "website": "https://locations.pizzahut.com/pa/allentown/3315-hamilton-blvd",
+   "openingHours": "Mo-Th,Su 10:30-23:00; Fr,Sa 10:30-24:00",
+   "brand": "Pizza Hut",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7928567584"
+  },
+  {
+   "id": "way/59416752",
+   "name": "Pizza Hut",
+   "address": "7720 Main Street, Fogelsville, PA",
+   "lat": 40.5827648,
+   "lng": -75.6265257,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-398-9010",
+   "website": "https://locations.pizzahut.com/pa/fogelsville/7720-main-st",
+   "openingHours": null,
+   "brand": "Pizza Hut",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/59416752"
+  },
+  {
+   "id": "way/504486475",
+   "name": "Pizza Hut",
+   "address": "1761 South 4th Street, Allentown, PA",
+   "lat": 40.5828962,
+   "lng": -75.4572584,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-797-6776",
+   "website": "https://locations.pizzahut.com/pa/allentown/1761-s-4th-st",
+   "openingHours": null,
+   "brand": "Pizza Hut",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/504486475"
+  },
+  {
+   "id": "node/4850672920",
+   "name": "Pizza Mart",
+   "address": "539 Hamilton Street, Allentown, PA",
+   "lat": 40.6029888,
+   "lng": -75.4693891,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4850672920"
+  },
+  {
+   "id": "node/5807665805",
+   "name": "Pizza Village",
+   "address": "",
+   "lat": 40.6746363,
+   "lng": -75.3869572,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665805"
+  },
+  {
+   "id": "node/7261113723",
+   "name": "Playa Bowls",
+   "address": "",
+   "lat": 40.5593018,
+   "lng": -75.4130068,
+   "types": [
+    "fast_food",
+    "açaí",
+    "takeaway"
+   ],
+   "cuisine": [
+    "açaí"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Playa Bowls",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7261113723"
+  },
+  {
+   "id": "node/12682720752",
+   "name": "Playa Bowls",
+   "address": "310 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6119464,
+   "lng": -75.3741425,
+   "types": [
+    "fast_food",
+    "açaí",
+    "takeaway"
+   ],
+   "cuisine": [
+    "açaí"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Playa Bowls",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720752"
+  },
+  {
+   "id": "way/39457075",
+   "name": "Plaza Azteca",
+   "address": "3731 PA 378, Bethlehem, PA",
+   "lat": 40.5874927,
+   "lng": -75.3858804,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": "yes",
+   "osmUrl": "https://www.openstreetmap.org/way/39457075"
+  },
+  {
+   "id": "way/846607618",
+   "name": "Plaza Azteca",
+   "address": "2835 Lehigh Street, Allentown, PA",
+   "lat": 40.5617304,
+   "lng": -75.4853006,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-656-7277",
+   "website": "https://plazaazteca.com/location-pennsylvania-plaza-azteca-allentown/",
+   "openingHours": "Mo-Th 11:00-22:00; Fr-Sa 11:00-22:30; Su 12:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846607618"
+  },
+  {
+   "id": "node/4378216057",
+   "name": "Pocono Brewery Co.",
+   "address": "",
+   "lat": 40.6292592,
+   "lng": -75.481018,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4378216057"
+  },
+  {
+   "id": "node/11904646182",
+   "name": "Poke Bar 25",
+   "address": "2910 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6474305,
+   "lng": -75.3391733,
+   "types": [
+    "restaurant",
+    "poke"
+   ],
+   "cuisine": [
+    "poke"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11904646182"
+  },
+  {
+   "id": "node/12920538351",
+   "name": "Poke Kai",
+   "address": "3337 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5790326,
+   "lng": -75.5253012,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12920538351"
+  },
+  {
+   "id": "node/12696504058",
+   "name": "Pokemoto",
+   "address": "4 Farrington Square, Bethlehem, PA",
+   "lat": 40.6095169,
+   "lng": -75.3785853,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12696504058"
+  },
+  {
+   "id": "node/11893016954",
+   "name": "Polish Water Ice",
+   "address": "7727 Glenlivet Drive West, Fogelsville, PA",
+   "lat": 40.5909893,
+   "lng": -75.6300734,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11893016954"
+  },
+  {
+   "id": "way/1305340381",
+   "name": "Pool Snack Bar",
+   "address": "",
+   "lat": 40.5085099,
+   "lng": -75.6066394,
+   "types": [
+    "fast_food",
+    "ice_cream",
+    "hot_dog",
+    "pretzel"
+   ],
+   "cuisine": [
+    "ice_cream",
+    "hot_dog",
+    "pretzel"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1305340381"
+  },
+  {
+   "id": "node/6907399010",
+   "name": "Popeyes",
+   "address": "1302 Hanover Avenue, Allentown, PA",
+   "lat": 40.6181872,
+   "lng": -75.434774,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway",
+    "delivery",
+    "drive_through"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-351-2015",
+   "website": "https://www.popeyes.com/store-locator/store/restaurant_84199",
+   "openingHours": "Mo-We 10:30-21:30; Th-Sa 10:30-22:00; Su 10:30-21:30",
+   "brand": "Popeyes",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6907399010"
+  },
+  {
+   "id": "way/610929638",
+   "name": "Popeyes",
+   "address": "1935 South 4th Street, Allentown, PA",
+   "lat": 40.579021,
+   "lng": -75.4545658,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Popeyes",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610929638"
+  },
+  {
+   "id": "way/1302652372",
+   "name": "Popeyes",
+   "address": "1141 MacArthur Road, Whitehall, PA",
+   "lat": 40.620664,
+   "lng": -75.4799061,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Popeyes",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1302652372"
+  },
+  {
+   "id": "node/13162491593",
+   "name": "PoppTeas",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5555231,
+   "lng": -75.4917495,
+   "types": [
+    "cafe",
+    "tea"
+   ],
+   "cuisine": [
+    "tea"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-350-3812",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13162491593"
+  },
+  {
+   "id": "node/9831810204",
+   "name": "Portugalia BBQ",
+   "address": "324 Main Street, Freemansburg, PA",
+   "lat": 40.6268032,
+   "lng": -75.3352712,
+   "types": [
+    "restaurant",
+    "portuguese"
+   ],
+   "cuisine": [
+    "portuguese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9831810204"
+  },
+  {
+   "id": "way/154239376",
+   "name": "Potsy Pizza",
+   "address": "5925 Tilghman Street, Allentown, PA",
+   "lat": 40.5915517,
+   "lng": -75.5932533,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103366136",
+   "website": "http://www.potsypizzapa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/154239376"
+  },
+  {
+   "id": "way/1515217879",
+   "name": "Potts' Dog Barn",
+   "address": "1438 Chestnut Street, Emmaus, PA",
+   "lat": 40.5262107,
+   "lng": -75.5115377,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1515217879"
+  },
+  {
+   "id": "node/5785275360",
+   "name": "Potts' Dog House",
+   "address": "",
+   "lat": 40.5090483,
+   "lng": -75.3870082,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5785275360"
+  },
+  {
+   "id": "node/13033340370",
+   "name": "Potts' Hot Dogs",
+   "address": "3570 West Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5769822,
+   "lng": -75.5271578,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13033340370"
+  },
+  {
+   "id": "way/1461453602",
+   "name": "Potts' Hot Dogs",
+   "address": "2675 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6452441,
+   "lng": -75.3451379,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1461453602"
+  },
+  {
+   "id": "node/12983007962",
+   "name": "Pour Bar",
+   "address": "101 Founder's Way, Bethlehem, PA",
+   "lat": 40.6140932,
+   "lng": -75.3675618,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12983007962"
+  },
+  {
+   "id": "node/1586402236",
+   "name": "Prime Steakhouse",
+   "address": "",
+   "lat": 40.660286,
+   "lng": -75.3905625,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1586402236"
+  },
+  {
+   "id": "node/13061246843",
+   "name": "Primo Pizza & Grill",
+   "address": "2431 Emaus Avenue, Allentown, PA",
+   "lat": 40.5659327,
+   "lng": -75.4750582,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061246843"
+  },
+  {
+   "id": "node/6307335749",
+   "name": "PrimoHoagies",
+   "address": "2410 Catasauqua Road, Bethlehem, PA",
+   "lat": 40.6434583,
+   "lng": -75.4269734,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "PrimoHoagies",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6307335749"
+  },
+  {
+   "id": "node/7929108214",
+   "name": "PrimoHoagies",
+   "address": "",
+   "lat": 40.6119792,
+   "lng": -75.5318661,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7929108214"
+  },
+  {
+   "id": "node/6206857231",
+   "name": "Puffins Cafe",
+   "address": "968 Hellertown Road, Bethlehem, PA",
+   "lat": 40.6015122,
+   "lng": -75.3413767,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6206857231"
+  },
+  {
+   "id": "node/6909493848",
+   "name": "Punta Cana",
+   "address": "801 Union Boulevard, Allentown, PA",
+   "lat": 40.6243508,
+   "lng": -75.4444521,
+   "types": [
+    "restaurant",
+    "lat"
+   ],
+   "cuisine": [
+    "lat"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493848"
+  },
+  {
+   "id": "way/266630973",
+   "name": "Pura's Burgers",
+   "address": "625 West Liberty Street, Allentown",
+   "lat": 40.6095258,
+   "lng": -75.4741616,
+   "types": [
+    "fast_food",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610 433 1950",
+   "website": "http://www.yoccos.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266630973"
+  },
+  {
+   "id": "node/13061217832",
+   "name": "Puzzles",
+   "address": "723 South 8th Street, Allentown, PA",
+   "lat": 40.5930941,
+   "lng": -75.469468,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061217832"
+  },
+  {
+   "id": "node/12709754716",
+   "name": "Qdoba",
+   "address": "2417 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6425387,
+   "lng": -75.4038002,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Qdoba",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12709754716"
+  },
+  {
+   "id": "way/531111537",
+   "name": "Qdoba",
+   "address": "2669 MacArthur Road, Whitehall, PA",
+   "lat": 40.6455787,
+   "lng": -75.4925168,
+   "types": [
+    "fast_food",
+    "mexican",
+    "takeaway"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-432-2119",
+   "website": "https://locations.qdoba.com/us/pa/whitehall/2669a-mac-arthur-rd.html",
+   "openingHours": "10:30-21:30",
+   "brand": "Qdoba",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531111537"
+  },
+  {
+   "id": "node/6932056548",
+   "name": "Queen City BBQ",
+   "address": "27 North 7th Street, Allentown, PA",
+   "lat": 40.6031158,
+   "lng": -75.4718702,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6932056548"
+  },
+  {
+   "id": "way/1273969120",
+   "name": "Race Street Bar & Grill",
+   "address": "429 Race Street, Catasauqua, PA",
+   "lat": 40.6513531,
+   "lng": -75.4624509,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14848202310",
+   "website": "https://www.facebook.com/racestreetbarandgrill",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1273969120"
+  },
+  {
+   "id": "way/1427947476",
+   "name": "Raising Cane's",
+   "address": "6240 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5561118,
+   "lng": -75.5781963,
+   "types": [
+    "fast_food",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Raising Cane's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1427947476"
+  },
+  {
+   "id": "node/13027864252",
+   "name": "Rakkii Ramen",
+   "address": "328 South New Street, Bethlehem, PA",
+   "lat": 40.610808,
+   "lng": -75.3786108,
+   "types": [
+    "restaurant",
+    "ramen"
+   ],
+   "cuisine": [
+    "ramen"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13027864252"
+  },
+  {
+   "id": "way/642046185",
+   "name": "Randall's on the Orchard",
+   "address": "2016 Applewood Drive, Orefield, PA",
+   "lat": 40.6095911,
+   "lng": -75.5956962,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103958000",
+   "website": "https://www.randalls.restaurant/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/642046185"
+  },
+  {
+   "id": "node/12682203756",
+   "name": "Rascals",
+   "address": "1350 MacArthur Road, Whitehall, PA",
+   "lat": 40.6244692,
+   "lng": -75.484922,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682203756"
+  },
+  {
+   "id": "node/6904094784",
+   "name": "Ray's Famous",
+   "address": "2302 Union Boulevard, Allentown, PA",
+   "lat": 40.625812,
+   "lng": -75.4217935,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904094784"
+  },
+  {
+   "id": "node/6944057766",
+   "name": "Red Barn Bar & Grill",
+   "address": "646 North 8th Street, Allentown",
+   "lat": 40.6111942,
+   "lng": -75.4783232,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6944057766"
+  },
+  {
+   "id": "way/30762336",
+   "name": "Red Lobster",
+   "address": "800 Lehigh Lifestyle Center, Whitehall, PA",
+   "lat": 40.6336222,
+   "lng": -75.479382,
+   "types": [
+    "restaurant",
+    "seafood"
+   ],
+   "cuisine": [
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102645541",
+   "website": "https://www.redlobster.com/seafood-restaurants/locations/pa/whitehall/800-lehigh-lifestyle-center/",
+   "openingHours": null,
+   "brand": "Red Lobster",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/30762336"
+  },
+  {
+   "id": "node/3866300406",
+   "name": "Red Robin",
+   "address": "",
+   "lat": 40.5605633,
+   "lng": -75.4099689,
+   "types": [
+    "restaurant",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Red Robin",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3866300406"
+  },
+  {
+   "id": "way/51578481",
+   "name": "Red Robin",
+   "address": "1875 Airport Road, Allentown, PA",
+   "lat": 40.6388525,
+   "lng": -75.4337864,
+   "types": [
+    "restaurant",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+16102661776",
+   "website": "https://locations.redrobin.com/pa/allentown/334/",
+   "openingHours": null,
+   "brand": "Red Robin",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/51578481"
+  },
+  {
+   "id": "way/223898404",
+   "name": "Red Robin",
+   "address": "",
+   "lat": 40.461335,
+   "lng": -75.3697988,
+   "types": [
+    "restaurant",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Red Robin",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/223898404"
+  },
+  {
+   "id": "way/278765343",
+   "name": "Red Robin",
+   "address": "4688 Broadway, Allentown, PA",
+   "lat": 40.588379,
+   "lng": -75.5596897,
+   "types": [
+    "restaurant",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": "Mo-Su 11:00-11:00",
+   "brand": "Red Robin",
+   "wheelchair": "limited",
+   "osmUrl": "https://www.openstreetmap.org/way/278765343"
+  },
+  {
+   "id": "node/6204630832",
+   "name": "Restaurante Mi Tierra",
+   "address": "558 Broadway, Bethlehem, PA",
+   "lat": 40.6074651,
+   "lng": -75.3871215,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6204630832"
+  },
+  {
+   "id": "node/6311941176",
+   "name": "Reunion",
+   "address": "2915 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.649178,
+   "lng": -75.4104572,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6311941176"
+  },
+  {
+   "id": "way/850597313",
+   "name": "Rice Family",
+   "address": "2952 Lehigh Street, Allentown, PA",
+   "lat": 40.5600463,
+   "lng": -75.4876207,
+   "types": [
+    "restaurant",
+    "chinese",
+    "japanese"
+   ],
+   "cuisine": [
+    "chinese",
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103511788",
+   "website": "https://www.ricefamilypa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/850597313"
+  },
+  {
+   "id": "node/13016581727",
+   "name": "Rice N’ Beans",
+   "address": "2330 Jacksonville Road, Bethlehem, PA",
+   "lat": 40.6416994,
+   "lng": -75.3998918,
+   "types": [
+    "fast_food",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13016581727"
+  },
+  {
+   "id": "way/1311082778",
+   "name": "Riley's Restaurant & Pub",
+   "address": "4505 Main Street, Whitehall, PA",
+   "lat": 40.6804159,
+   "lng": -75.530098,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102629911",
+   "website": "https://www.facebook.com/friendliestplaceintown/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1311082778"
+  },
+  {
+   "id": "node/6943158014",
+   "name": "Rincon del Pueblo Restaurant",
+   "address": "546 North 7th Street, Allentown, PA",
+   "lat": 40.6103647,
+   "lng": -75.4757631,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158014"
+  },
+  {
+   "id": "node/831649276",
+   "name": "Ripper's Pub",
+   "address": "77 West Broad Street, Bethlehem, PA",
+   "lat": 40.622181,
+   "lng": -75.3808052,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [
+    "pub"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-866-6646",
+   "website": null,
+   "openingHours": "11:00-02:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649276"
+  },
+  {
+   "id": "node/1312655089",
+   "name": "Rita's Italian Ice",
+   "address": "1130 Main Street",
+   "lat": 40.5856341,
+   "lng": -75.3415728,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1312655089"
+  },
+  {
+   "id": "node/3566468421",
+   "name": "Rita's Italian Ice",
+   "address": "1907 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6404464,
+   "lng": -75.3481854,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3566468421"
+  },
+  {
+   "id": "node/6904198072",
+   "name": "Rita's Italian Ice",
+   "address": "1905 Union Boulevard, Allentown, PA",
+   "lat": 40.6257281,
+   "lng": -75.4275563,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904198072"
+  },
+  {
+   "id": "node/8023598980",
+   "name": "Rita's Italian Ice",
+   "address": "",
+   "lat": 40.5789994,
+   "lng": -75.5309042,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/ritas",
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8023598980"
+  },
+  {
+   "id": "node/12217085443",
+   "name": "Rita's Italian Ice",
+   "address": "4041 PA 309, Schnecksville, PA",
+   "lat": 40.6571312,
+   "lng": -75.6001166,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-799-5383",
+   "website": "https://www.ritasice.com/location/ritas-of-schnecksville-pa/",
+   "openingHours": "12:00-21:00",
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12217085443"
+  },
+  {
+   "id": "node/12741597580",
+   "name": "Rita's Italian Ice",
+   "address": "7001 North Route 309, Coopersburg, PA",
+   "lat": 40.5179191,
+   "lng": -75.3877237,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12741597580"
+  },
+  {
+   "id": "node/13111127711",
+   "name": "Rita's Italian Ice",
+   "address": "2015 Main Street, Northampton, PA",
+   "lat": 40.6900159,
+   "lng": -75.498876,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13111127711"
+  },
+  {
+   "id": "way/531129127",
+   "name": "Rita's Italian Ice",
+   "address": "2874 MacArthur Road, Whitehall, PA",
+   "lat": 40.6484038,
+   "lng": -75.4977143,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104391100",
+   "website": "https://www.ritasice.com/location/ritas-of-whitehall-pa/",
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531129127"
+  },
+  {
+   "id": "way/671873385",
+   "name": "Rita's Italian Ice",
+   "address": "405 South Best Avenue, Walnutport, PA",
+   "lat": 40.7524545,
+   "lng": -75.5915622,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/671873385"
+  },
+  {
+   "id": "way/787540649",
+   "name": "Rita's Italian Ice",
+   "address": "",
+   "lat": 40.7064132,
+   "lng": -75.5061612,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/787540649"
+  },
+  {
+   "id": "way/860873789",
+   "name": "Rita's Italian Ice",
+   "address": "",
+   "lat": 40.5779911,
+   "lng": -75.5363883,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/ritas",
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860873789"
+  },
+  {
+   "id": "way/1273947253",
+   "name": "Rita's Italian Ice",
+   "address": "5681 Hamilton Boulevard, Wescosville, PA",
+   "lat": 40.5606589,
+   "lng": -75.5679174,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104819310",
+   "website": "https://www.ritasice.com/location/ritas-of-wescosville-pa/",
+   "openingHours": "Mo-Su 12:00-21:00",
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1273947253"
+  },
+  {
+   "id": "way/1301442417",
+   "name": "Rita's Italian Ice",
+   "address": "1052 Emaus Avenue, Allentown, PA",
+   "lat": 40.5704059,
+   "lng": -75.470298,
+   "types": [
+    "ice_cream",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107976666",
+   "website": "https://www.ritasice.com/location/ritas-of-emaus-avenue-pa/",
+   "openingHours": "Mo-Su 12:00-22:00",
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1301442417"
+  },
+  {
+   "id": "way/1446715002",
+   "name": "Rita's Italian Ice",
+   "address": "100 West Main Street, Macungie, PA",
+   "lat": 40.5171545,
+   "lng": -75.5591827,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109665560",
+   "website": "https://www.ritasice.com/location/ritas-of-macungie-pa/",
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1446715002"
+  },
+  {
+   "id": "way/1515217877",
+   "name": "Rita's Italian Ice",
+   "address": "1458 Chestnut Street, Emmaus, PA",
+   "lat": 40.5257299,
+   "lng": -75.5118591,
+   "types": [
+    "ice_cream",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-965-6899",
+   "website": "https://www.ritasice.com/location/ritas-of-emmaus-pa/",
+   "openingHours": "12:00-21:00",
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1515217877"
+  },
+  {
+   "id": "way/1524515029",
+   "name": "Rita's Italian Ice",
+   "address": "1912 West Tilghman Street, Allentown, PA",
+   "lat": 40.6046051,
+   "lng": -75.5013938,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [
+    "ice_cream"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104354501",
+   "website": "https://www.ritasice.com/location/ritas-of-tilghman-pa/",
+   "openingHours": null,
+   "brand": "Rita's Italian Ice",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1524515029"
+  },
+  {
+   "id": "node/3090692879",
+   "name": "Ritz Barbecue",
+   "address": "302 North 17th Street, Allentown",
+   "lat": 40.601373,
+   "lng": -75.4962194,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.ritzbarbecue.com/",
+   "openingHours": "Mo-Su 11:00-20:00; We-Sa 11:00-21:00",
+   "brand": null,
+   "wheelchair": "yes",
+   "osmUrl": "https://www.openstreetmap.org/node/3090692879"
+  },
+  {
+   "id": "node/1339057448",
+   "name": "Roasted Bethlehem",
+   "address": "22 West 4th Street, Bethlehem, PA",
+   "lat": 40.6103288,
+   "lng": -75.3793579,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 849 2673",
+   "website": "https://www.roastedbethlehem.com/",
+   "openingHours": "Tu-Su 07:00-14:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1339057448"
+  },
+  {
+   "id": "way/346603093",
+   "name": "Rocco's Pizzeria",
+   "address": "1120 Main Street, Hellertown, PA",
+   "lat": 40.5853637,
+   "lng": -75.3416251,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/346603093"
+  },
+  {
+   "id": "node/1308489203",
+   "name": "Roma Pizza",
+   "address": "",
+   "lat": 40.5793257,
+   "lng": -75.3410196,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1308489203"
+  },
+  {
+   "id": "node/6209304783",
+   "name": "Rosa's Bar & Grill",
+   "address": "1322 East 4th Street, Bethlehem, PA",
+   "lat": 40.6113957,
+   "lng": -75.3552573,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6209304783"
+  },
+  {
+   "id": "node/5794800242",
+   "name": "Rosemont Fire Company",
+   "address": "1832 West North Street, Bethlehem, PA",
+   "lat": 40.6239944,
+   "lng": -75.4098071,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5794800242"
+  },
+  {
+   "id": "node/7975349670",
+   "name": "Rossi's Pizza & Italian",
+   "address": "",
+   "lat": 40.5490232,
+   "lng": -75.4909117,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7975349670"
+  },
+  {
+   "id": "node/4719624616",
+   "name": "Roy Rogers",
+   "address": "Allentown Service Plaza",
+   "lat": 40.5744363,
+   "lng": -75.5576574,
+   "types": [
+    "fast_food",
+    "burger",
+    "sandwich",
+    "chicken",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger",
+    "sandwich",
+    "chicken"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Roy Rogers",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4719624616"
+  },
+  {
+   "id": "way/1299929680",
+   "name": "Rozana Mediterranean Restaurant & Banquet Hall",
+   "address": "2678 Eberhart Road, Whitehall, PA",
+   "lat": 40.6506633,
+   "lng": -75.4927511,
+   "types": [
+    "restaurant",
+    "mediterranean"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104430695",
+   "website": "https://www.rozanabanquetrestaurant.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1299929680"
+  },
+  {
+   "id": "node/6340862871",
+   "name": "Ruby Cafe",
+   "address": "1519 Easton Avenue, Bethlehem, PA",
+   "lat": 40.633549,
+   "lng": -75.367249,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6340862871"
+  },
+  {
+   "id": "node/1961335513",
+   "name": "Ruby Tuesday",
+   "address": "2102 Emrick Boulevardt, Bethlehem, PA",
+   "lat": 40.6522566,
+   "lng": -75.2905349,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://www.rubytuesday.com/",
+   "openingHours": null,
+   "brand": "Ruby Tuesday",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1961335513"
+  },
+  {
+   "id": "node/6341470179",
+   "name": "Rudy's Diner Bar & Grill",
+   "address": "1406 Center Street, Bethlehem, PA",
+   "lat": 40.6323807,
+   "lng": -75.3748557,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6341470179"
+  },
+  {
+   "id": "way/889593060",
+   "name": "Ruffino's Italian Kitchen and Pizzaria",
+   "address": "5840 Chestnut Street, Zionsville, PA",
+   "lat": 40.4871707,
+   "lng": -75.5238504,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109662021",
+   "website": "https://ruffinos5840.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/889593060"
+  },
+  {
+   "id": "node/13162491592",
+   "name": "S&D Soulicious Cuisine",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5552068,
+   "lng": -75.4922251,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-351-1060",
+   "website": "https://sanddscuisine.square.site/",
+   "openingHours": "Mo-Fr 12:00-20:00; Sa 11:00-20:00; Su 11:00-17:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13162491592"
+  },
+  {
+   "id": "way/600907438",
+   "name": "Sage Alley Brewery & Grille",
+   "address": "213 North Main Street, Coopersburg, PA",
+   "lat": 40.5136936,
+   "lng": -75.3896589,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104216029",
+   "website": "https://www.sagealleybrewery.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/600907438"
+  },
+  {
+   "id": "node/3766570511",
+   "name": "Sagra Bistro",
+   "address": "620 Main Street, Hellertown, PA",
+   "lat": 40.578225,
+   "lng": -75.340897,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3766570511"
+  },
+  {
+   "id": "node/13127905235",
+   "name": "Sahara Mediterranean Cuisine",
+   "address": "5661 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5613534,
+   "lng": -75.5675825,
+   "types": [
+    "restaurant",
+    "mediterranean"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13127905235"
+  },
+  {
+   "id": "node/9401055493",
+   "name": "Sal's Pizza",
+   "address": "4767 Tilghman Street, Allentown, PA",
+   "lat": 40.5904382,
+   "lng": -75.5620541,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9401055493"
+  },
+  {
+   "id": "node/10028204546",
+   "name": "Sal's Pizza",
+   "address": "102 Main Street, Slatington",
+   "lat": 40.7528028,
+   "lng": -75.6051222,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway",
+    "delivery",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1-610-760-1561",
+   "website": "https://www.salspizzafamilyrestaurant.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10028204546"
+  },
+  {
+   "id": "node/5157429400",
+   "name": "Saladworks",
+   "address": "2419 MacArthur Road, Whitehall, PA",
+   "lat": 40.6426335,
+   "lng": -75.4903591,
+   "types": [
+    "fast_food",
+    "salad",
+    "takeaway"
+   ],
+   "cuisine": [
+    "salad"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-434-5400",
+   "website": "https://restaurants.saladworks.com/pa/whitehall/2419-macarthur-road/",
+   "openingHours": "Mo-Sa 11:00-20:00; Su 11:00-19:00",
+   "brand": "Saladworks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5157429400"
+  },
+  {
+   "id": "node/6311987072",
+   "name": "Saladworks",
+   "address": "3215 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6568434,
+   "lng": -75.4182185,
+   "types": [
+    "fast_food",
+    "salad",
+    "takeaway"
+   ],
+   "cuisine": [
+    "salad"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Saladworks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6311987072"
+  },
+  {
+   "id": "node/7929108213",
+   "name": "Saladworks",
+   "address": "",
+   "lat": 40.6118714,
+   "lng": -75.5318149,
+   "types": [
+    "fast_food",
+    "salad",
+    "takeaway"
+   ],
+   "cuisine": [
+    "salad"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": "Mo-Su 10:00-21:00",
+   "brand": "Saladworks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7929108213"
+  },
+  {
+   "id": "way/641918205",
+   "name": "Salvatore's Pizzeria",
+   "address": "174 East Main Street, Macungie, PA",
+   "lat": 40.5138276,
+   "lng": -75.5522332,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109662844",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/641918205"
+  },
+  {
+   "id": "node/11893018710",
+   "name": "Sam's Pizza & Pasta",
+   "address": "5041 PA 873, Schnecksville, PA",
+   "lat": 40.6775851,
+   "lng": -75.6128773,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-799-6500",
+   "website": "https://www.samspizzapasta.net/",
+   "openingHours": "Mo,We-Th 10:00-20:00; Tu off; Fr-Sa 10:00-20:30; Su 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11893018710"
+  },
+  {
+   "id": "node/9875328312",
+   "name": "Samuel Owens Casual Family Dining",
+   "address": "128 Chestnut Street, Coplay, PA",
+   "lat": 40.6744292,
+   "lng": -75.4930002,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9875328312"
+  },
+  {
+   "id": "node/6937616360",
+   "name": "Sandwichera El Punto",
+   "address": "410 Tilghman Street, Allentown, PA",
+   "lat": 40.6131688,
+   "lng": -75.470403,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6937616360"
+  },
+  {
+   "id": "node/367977010",
+   "name": "Santa Fe Taco Company",
+   "address": "",
+   "lat": 40.6902051,
+   "lng": -75.4992868,
+   "types": [
+    "restaurant",
+    "tacos"
+   ],
+   "cuisine": [
+    "tacos"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/367977010"
+  },
+  {
+   "id": "node/6925915962",
+   "name": "Sarandonga",
+   "address": "223 Hamilton Street, Allentown",
+   "lat": 40.6056229,
+   "lng": -75.4615241,
+   "types": [
+    "restaurant",
+    "latin_american"
+   ],
+   "cuisine": [
+    "latin_american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-821-4888",
+   "website": "https://www.sarandongalatinbistropa.com/",
+   "openingHours": "Mo,Tu off; We,Th 16:00-23:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6925915962"
+  },
+  {
+   "id": "node/7367072094",
+   "name": "Savory Grille",
+   "address": "2934 Seisholtzville Road, Macungie, PA",
+   "lat": 40.4694053,
+   "lng": -75.6050345,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7367072094"
+  },
+  {
+   "id": "node/3746296714",
+   "name": "Saxbys Coffee",
+   "address": "3 West Morton Street, Bethlehem, PA",
+   "lat": 40.6099297,
+   "lng": -75.378707,
+   "types": [
+    "cafe",
+    "coffee_shop"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-865-2031",
+   "website": "https://www.saxbyscoffee.com/location/saxbys-lehigh-university/",
+   "openingHours": "Mo-Fr 07:00-17:00; Sa,Su 08:00-17:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3746296714"
+  },
+  {
+   "id": "way/1349339947",
+   "name": "Sazon Dominicano Restaurante",
+   "address": "215 Bridge Street, Catasauqua, PA",
+   "lat": 40.6543561,
+   "lng": -75.4727731,
+   "types": [
+    "restaurant",
+    "dominican"
+   ],
+   "cuisine": [
+    "dominican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1349339947"
+  },
+  {
+   "id": "node/13019488588",
+   "name": "Sbarro",
+   "address": "Allentown Service Plaza",
+   "lat": 40.5745527,
+   "lng": -75.5577243,
+   "types": [
+    "fast_food",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Sbarro",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019488588"
+  },
+  {
+   "id": "node/11515467052",
+   "name": "Scoopendorf’s Ice Cream Company",
+   "address": "350 South Best Avenue, Walnutport, PA",
+   "lat": 40.75278,
+   "lng": -75.5915619,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11515467052"
+  },
+  {
+   "id": "node/13016692516",
+   "name": "Secrets Lounge",
+   "address": "1004 East Livingston Street, Allentown, PA",
+   "lat": 40.6249637,
+   "lng": -75.4416081,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13016692516"
+  },
+  {
+   "id": "way/1307156401",
+   "name": "Seemsville Pub",
+   "address": "3819 Seemsville Road, Northampton, PA",
+   "lat": 40.7220581,
+   "lng": -75.4585661,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1307156401"
+  },
+  {
+   "id": "node/12971713159",
+   "name": "Seven Sirens Brewing Company",
+   "address": "327 Broadway, Bethlehem, PA",
+   "lat": 40.6099236,
+   "lng": -75.383617,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12971713159"
+  },
+  {
+   "id": "way/1418279219",
+   "name": "Sewards Steak Shop",
+   "address": "202 South 17th Street, Allentown, PA",
+   "lat": 40.5938743,
+   "lng": -75.4912225,
+   "types": [
+    "fast_food",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1418279219"
+  },
+  {
+   "id": "way/1281275476",
+   "name": "Shake Shack",
+   "address": "1457 MacArthur Road, Whitehall, PA",
+   "lat": 40.6281963,
+   "lng": -75.4830424,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+15703008694",
+   "website": "https://shakeshack.com/location/lehigh-valley-mall-pa",
+   "openingHours": null,
+   "brand": "Shake Shack",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1281275476"
+  },
+  {
+   "id": "node/6206792389",
+   "name": "Shang Wei Szechuan",
+   "address": "1 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6120946,
+   "lng": -75.3784138,
+   "types": [
+    "restaurant",
+    "chinese",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 882 1248",
+   "website": "https://www.shangweiszechuan.com/",
+   "openingHours": "Mo-Th 11:00-21:45; Fr-Sa 11:00-22:30; Su 11:30-21:45",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6206792389"
+  },
+  {
+   "id": "way/964194787",
+   "name": "Shanty on 19th",
+   "address": "613 North 19th Street, Allentown, PA",
+   "lat": 40.6043404,
+   "lng": -75.5002103,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/964194787"
+  },
+  {
+   "id": "node/6221940194",
+   "name": "Sibris",
+   "address": "147 East Broad Street, Bethlehem, PA",
+   "lat": 40.6223863,
+   "lng": -75.3734635,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6221940194"
+  },
+  {
+   "id": "node/3561965410",
+   "name": "Sicily Restaurant",
+   "address": "",
+   "lat": 40.6661927,
+   "lng": -75.3078744,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3561965410"
+  },
+  {
+   "id": "node/13022255704",
+   "name": "Singh's Bar & Grill",
+   "address": "448 North 9th Street, Allentown, PA",
+   "lat": 40.6080592,
+   "lng": -75.4788556,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13022255704"
+  },
+  {
+   "id": "node/12682720754",
+   "name": "Sizzling Bites Halal",
+   "address": "312 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6119556,
+   "lng": -75.3739195,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720754"
+  },
+  {
+   "id": "node/5266156094",
+   "name": "Slate Quarry Hotel",
+   "address": "",
+   "lat": 40.7413893,
+   "lng": -75.3471482,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5266156094"
+  },
+  {
+   "id": "way/1312672457",
+   "name": "Sliders Pub & GRILL",
+   "address": "4650 PA 309, Schnecksville, PA",
+   "lat": 40.669985,
+   "lng": -75.6082251,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107694004",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1312672457"
+  },
+  {
+   "id": "way/1157144041",
+   "name": "Slovak Center",
+   "address": "1233 5th Street, North Catasauqua",
+   "lat": 40.6625427,
+   "lng": -75.4780323,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1157144041"
+  },
+  {
+   "id": "node/5821469643",
+   "name": "Smashburger",
+   "address": "",
+   "lat": 40.5656522,
+   "lng": -75.5622497,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://smashburger.com/locations/us/pa/allentown/707-n-krocks-rd",
+   "openingHours": null,
+   "brand": "Smashburger",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469643"
+  },
+  {
+   "id": "node/6169323706",
+   "name": "Smmackin Sammiches II",
+   "address": "404 West Broad Street, Bethlehem, PA",
+   "lat": 40.6225921,
+   "lng": -75.3883687,
+   "types": [
+    "restaurant",
+    "american",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 4814",
+   "website": null,
+   "openingHours": "Mo-Fr 08:00-17:00; Sa 08:00-15:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6169323706"
+  },
+  {
+   "id": "way/882838880",
+   "name": "Smoothie King",
+   "address": "2701 MacArthur Road, Whitehall, PA",
+   "lat": 40.646555,
+   "lng": -75.4926769,
+   "types": [
+    "fast_food",
+    "juice",
+    "takeaway"
+   ],
+   "cuisine": [
+    "juice"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Smoothie King",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/882838880"
+  },
+  {
+   "id": "way/262966926",
+   "name": "Smuggler's Snacks",
+   "address": "",
+   "lat": 40.5794466,
+   "lng": -75.5285511,
+   "types": [
+    "fast_food",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/smugglers-snacks",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/262966926"
+  },
+  {
+   "id": "way/596510835",
+   "name": "Social Still",
+   "address": "530 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6119902,
+   "lng": -75.3708554,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/596510835"
+  },
+  {
+   "id": "node/12709754714",
+   "name": "SoFresh",
+   "address": "2413 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6424448,
+   "lng": -75.403708,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12709754714"
+  },
+  {
+   "id": "way/1414195869",
+   "name": "Something Different",
+   "address": "754 Cherokee Street, Bethlehem, PA",
+   "lat": 40.6068755,
+   "lng": -75.3900358,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108672441",
+   "website": "https://somethingdifferent.food/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1414195869"
+  },
+  {
+   "id": "way/1278087230",
+   "name": "Sonic",
+   "address": "1753 Airport Road, Allentown, PA",
+   "lat": 40.6360484,
+   "lng": -75.436438,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-264-1662",
+   "website": "https://locations.sonicdrivein.com/pa/allentown/1753-airport-road.html",
+   "openingHours": "Mo-Th 09:00-22:00; Fr-Sa 09:00-23:00; Su 09:00-22:00",
+   "brand": "Sonic",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278087230"
+  },
+  {
+   "id": "node/6904094780",
+   "name": "Sopranos Pizza",
+   "address": "2102 Union Boulevard, Allentown, PA",
+   "lat": 40.6255855,
+   "lng": -75.4238423,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904094780"
+  },
+  {
+   "id": "node/1339057452",
+   "name": "Sotto Santi Pizzeria Pub",
+   "address": "10 West 4th Street, Bethlehem, PA",
+   "lat": 40.6103215,
+   "lng": -75.3788193,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1339057452"
+  },
+  {
+   "id": "node/13025819356",
+   "name": "South Philly Steaks & Fries",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145255,
+   "lng": -75.358334,
+   "types": [
+    "fast_food",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819356"
+  },
+  {
+   "id": "node/11905054593",
+   "name": "South Side Pizza",
+   "address": "704 Emaus Avenue, Allentown, PA",
+   "lat": 40.573821,
+   "lng": -75.4613186,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905054593"
+  },
+  {
+   "id": "node/327048380",
+   "name": "Southside 313",
+   "address": "313 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6122022,
+   "lng": -75.37407,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/327048380"
+  },
+  {
+   "id": "way/468914275",
+   "name": "Spice Route Indian Restaurant",
+   "address": "845 West Linden Street, Allentown, PA",
+   "lat": 40.6028503,
+   "lng": -75.4760459,
+   "types": [
+    "restaurant",
+    "indian"
+   ],
+   "cuisine": [
+    "indian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16106803100",
+   "website": "https://www.spicerouteallentown.com/",
+   "openingHours": "Mo-Su 11:30-21:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/468914275"
+  },
+  {
+   "id": "node/6966860172",
+   "name": "Spinnerstown Hotel",
+   "address": "",
+   "lat": 40.439085,
+   "lng": -75.4368081,
+   "types": [
+    "restaurant",
+    "american",
+    "burger",
+    "seafood"
+   ],
+   "cuisine": [
+    "american",
+    "burger",
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "Su closed; Mo-Sa unknown",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6966860172"
+  },
+  {
+   "id": "way/610922941",
+   "name": "Spinnerstown Hotel Restaurant & Taproom",
+   "address": "",
+   "lat": 40.4390813,
+   "lng": -75.4368059,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610922941"
+  },
+  {
+   "id": "way/350989158",
+   "name": "Spiro's Family Restaurant",
+   "address": "710 Washington Street, Freemansburg, PA",
+   "lat": 40.6293897,
+   "lng": -75.3430205,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/350989158"
+  },
+  {
+   "id": "node/13759061224",
+   "name": "Sports & Social Allentown",
+   "address": "645 Hamilton Street, Allentown, PA",
+   "lat": 40.6026497,
+   "lng": -75.4714765,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13759061224"
+  },
+  {
+   "id": "node/6925621777",
+   "name": "Sportsmen's Cafe",
+   "address": "341 Ridge Avenue, Allentown",
+   "lat": 40.6113287,
+   "lng": -75.4602348,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6925621777"
+  },
+  {
+   "id": "way/204139424",
+   "name": "Spot Drive-In",
+   "address": "",
+   "lat": 40.6935276,
+   "lng": -75.3348072,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/204139424"
+  },
+  {
+   "id": "way/347358070",
+   "name": "Springfield Diner Family Restaurant",
+   "address": "",
+   "lat": 40.5220596,
+   "lng": -75.2932971,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/347358070"
+  },
+  {
+   "id": "way/347310671",
+   "name": "Springtown Inn",
+   "address": "",
+   "lat": 40.5569178,
+   "lng": -75.284315,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/347310671"
+  },
+  {
+   "id": "node/6904198066",
+   "name": "Stahley's",
+   "address": "1826 Hanover Avenue, Allentown, PA",
+   "lat": 40.6210756,
+   "lng": -75.4278285,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904198066"
+  },
+  {
+   "id": "node/3992063335",
+   "name": "Starbucks",
+   "address": "3209 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6566298,
+   "lng": -75.4180189,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-264-1405",
+   "website": "https://www.starbucks.com/store-locator/store/10779/bethlehem-3209-schoenersville-road-bethlehem-pa-180172103-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3992063335"
+  },
+  {
+   "id": "node/4033114033",
+   "name": "Starbucks",
+   "address": "1850 Airport Road, Allentown, PA",
+   "lat": 40.6387809,
+   "lng": -75.435369,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-264-2085",
+   "website": "https://www.starbucks.com/store-locator/store/89213/airport-road-1850-airport-road-allentown-pa-181099545-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4033114033"
+  },
+  {
+   "id": "node/4378162860",
+   "name": "Starbucks",
+   "address": "645 West Hamilton, Allentown, PA",
+   "lat": 40.6024579,
+   "lng": -75.4713508,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-841-4770",
+   "website": "https://www.starbucks.com/store-locator/store/1012168/two-city-center-1st-floor-645-west-hamilton-x-allentown-pa-18101-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4378162860"
+  },
+  {
+   "id": "node/5800087244",
+   "name": "Starbucks",
+   "address": "4025 West Tilghman Street, Allentown, PA",
+   "lat": 40.5933229,
+   "lng": -75.545442,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-530-1425",
+   "website": "https://www.starbucks.com/store-locator/store/6661/tilghman-st-4025-w-tilghman-street-allentown-pa-181044425-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087244"
+  },
+  {
+   "id": "node/5800087422",
+   "name": "Starbucks",
+   "address": "250 Lehigh Valley Mall, Whitehall, PA",
+   "lat": 40.6310867,
+   "lng": -75.480012,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 717-345-2968",
+   "website": "https://www.starbucks.com/store-locator/store/1040083/lehigh-valley-mall-kiosk-250-lehigh-valley-mall-k-102-whitehall-pa-18052-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5800087422"
+  },
+  {
+   "id": "node/5898000861",
+   "name": "Starbucks",
+   "address": "502 East 3rd Street, Bethlehem, PA",
+   "lat": 40.612012,
+   "lng": -75.3718624,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-419-3600",
+   "website": "https://www.starbucks.com/store-locator/store/1022482/greenway-commons-bethlehem-502-east-3rd-st-bethlehem-pa-18015-us",
+   "openingHours": "Mo-Su 06:00-22:00",
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5898000861"
+  },
+  {
+   "id": "node/5983968700",
+   "name": "Starbucks",
+   "address": "4727 Freemansburg Avenue, Bethlehem, PA",
+   "lat": 40.650497,
+   "lng": -75.2942017,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 484 553 6638",
+   "website": "https://www.starbucks.com/store-locator/store/1009883/madison-farms-4727-freemansburg-avenue-bethlehem-pa-180455529-us",
+   "openingHours": "Mo-Fr 05:00-22:00; Sa 05:30-22:00; Su 05:30-21:30",
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5983968700"
+  },
+  {
+   "id": "node/13016674801",
+   "name": "Starbucks",
+   "address": "912 Airport Center Road, Allentown, PA",
+   "lat": 40.638907,
+   "lng": -75.4398059,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13016674801"
+  },
+  {
+   "id": "node/13025819350",
+   "name": "Starbucks",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6148581,
+   "lng": -75.3585227,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819350"
+  },
+  {
+   "id": "node/13154194866",
+   "name": "Starbucks",
+   "address": "2409 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6423605,
+   "lng": -75.4036093,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13154194866"
+  },
+  {
+   "id": "way/846607609",
+   "name": "Starbucks",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5566709,
+   "lng": -75.4896442,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-791-4716",
+   "website": "https://www.starbucks.com/store-locator/store/7351/south-mall-3300-lehigh-street-allentown-pa-181037041-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846607609"
+  },
+  {
+   "id": "way/882841615",
+   "name": "Starbucks",
+   "address": "2630 MacArthur Road, Whitehall, PA",
+   "lat": 40.6455884,
+   "lng": -75.4942693,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-248-5457",
+   "website": "https://www.starbucks.com/store-locator/store/1028463/whitehall-mac-arthur-road-2630-mac-arthur-rd-suite-100-whitehall-pa-18052381",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/882841615"
+  },
+  {
+   "id": "way/1143791906",
+   "name": "Starbucks",
+   "address": "750 North Krocks Road, Allentown, PA",
+   "lat": 40.565193,
+   "lng": -75.564946,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 484-788-4486",
+   "website": "https://www.starbucks.com/store-locator/store/1025079/hamilton-crossings-trexlertow-750-n-krocks-rd-suite-101-allentown-pa-181069079-u",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1143791906"
+  },
+  {
+   "id": "way/1191618002",
+   "name": "Starbucks",
+   "address": "25 Main Street, Hellertown, PA",
+   "lat": 40.5673787,
+   "lng": -75.3393498,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 484-729-0002",
+   "website": "https://www.starbucks.com/store-locator/store/1033470/hellertown-25-main-street-hellertown-pa-180551742-us",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1191618002"
+  },
+  {
+   "id": "way/1278655759",
+   "name": "Starbucks",
+   "address": "Lehigh Valley, PA",
+   "lat": 40.5602036,
+   "lng": -75.4109756,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-791-3056",
+   "website": "https://www.starbucks.com/store-locator/store/17482/shops-at-saucon-valley-2900-center-valley-parkway-lehigh-valley-pa-180349",
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278655759"
+  },
+  {
+   "id": "way/1461453601",
+   "name": "Starbucks",
+   "address": "2675 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6450563,
+   "lng": -75.3456427,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Starbucks",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1461453601"
+  },
+  {
+   "id": "node/3370231042",
+   "name": "Starlite Diner",
+   "address": "",
+   "lat": 40.5766651,
+   "lng": -75.6211928,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "Su 05:30-21:00; Mo-Sa 05:30-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3370231042"
+  },
+  {
+   "id": "node/4885851953",
+   "name": "Stations Cafe",
+   "address": "559 Main Street, Bethlehem, PA",
+   "lat": 40.6219559,
+   "lng": -75.382213,
+   "types": [
+    "restaurant",
+    "vietnamese",
+    "noodle",
+    "sandwich"
+   ],
+   "cuisine": [
+    "vietnamese",
+    "noodle",
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-625-5200",
+   "website": "http://www.stationscafe.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4885851953"
+  },
+  {
+   "id": "node/13019514465",
+   "name": "STAY Restaurant & Bar",
+   "address": "7736 Adrienne Drive, Breinigsville, PA",
+   "lat": 40.5773065,
+   "lng": -75.6253949,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13019514465"
+  },
+  {
+   "id": "node/11158222087",
+   "name": "Steak & Steel Hibachi",
+   "address": "44 West Walnut Street, Bethlehem, PA",
+   "lat": 40.6217197,
+   "lng": -75.3803868,
+   "types": [
+    "restaurant",
+    "japanese",
+    "takeaway"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 849 2323",
+   "website": "https://www.steakandsteelpa.com/",
+   "openingHours": "Mo-Th 11:00-21:30; Fr,Sa 11:00-22:30; Su 11:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11158222087"
+  },
+  {
+   "id": "node/12714807046",
+   "name": "Steel City Gyro",
+   "address": "",
+   "lat": 40.551476,
+   "lng": -75.5919693,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12714807046"
+  },
+  {
+   "id": "node/13183347483",
+   "name": "Steelgaarden",
+   "address": "569 Main Street, Bethlehem, PA",
+   "lat": 40.6222832,
+   "lng": -75.3823547,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13183347483"
+  },
+  {
+   "id": "node/13025819351",
+   "name": "Steelworkers Buffet & Grill",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6148839,
+   "lng": -75.3579281,
+   "types": [
+    "restaurant",
+    "american",
+    "buffet"
+   ],
+   "cuisine": [
+    "american",
+    "buffet"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819351"
+  },
+  {
+   "id": "way/350933133",
+   "name": "Stefko Pizza",
+   "address": "2115 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6427551,
+   "lng": -75.3466309,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/350933133"
+  },
+  {
+   "id": "way/440116162",
+   "name": "Stonewall Moose Lounge Bar & Grille",
+   "address": "28 North 10th Street, Allentown, PA",
+   "lat": 40.6013424,
+   "lng": -75.4785928,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/440116162"
+  },
+  {
+   "id": "way/1393463441",
+   "name": "Strange Brew Tavern",
+   "address": "1996 South 5th Street, Allentown, PA",
+   "lat": 40.5771796,
+   "lng": -75.4560036,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108413610",
+   "website": "https://www.strangebrewtavern.co/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1393463441"
+  },
+  {
+   "id": "node/1016377176",
+   "name": "Subway",
+   "address": "1 East 4th Street, Bethlehem, PA",
+   "lat": 40.6105673,
+   "lng": -75.3783108,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-868-7570",
+   "website": "https://restaurants.subway.com/united-states/pa/bethlehem/1-east-4th-street",
+   "openingHours": "09:00-22:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1016377176"
+  },
+  {
+   "id": "node/3575589717",
+   "name": "Subway",
+   "address": "216 East Fairmont Street, Coopersburg, PA",
+   "lat": 40.516856,
+   "lng": -75.3850102,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-863-9090",
+   "website": "https://restaurants.subway.com/united-states/pa/coopersburg/216-e-fairmont-street",
+   "openingHours": "08:30-21:30",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3575589717"
+  },
+  {
+   "id": "node/4326257133",
+   "name": "Subway",
+   "address": "4664 Broadway, Allentown, PA",
+   "lat": 40.5880333,
+   "lng": -75.5611344,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-398-7744",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/4664-broadway-rd",
+   "openingHours": "Mo-Sa 08:00-21:00; Su 09:30-20:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4326257133"
+  },
+  {
+   "id": "node/4393598191",
+   "name": "Subway",
+   "address": "5040 PA 873, Schnecksville, PA",
+   "lat": 40.6779377,
+   "lng": -75.6155103,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-799-2525",
+   "website": "https://restaurants.subway.com/united-states/pa/schnecksville/5040-route-873",
+   "openingHours": "09:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4393598191"
+  },
+  {
+   "id": "node/5807665803",
+   "name": "Subway",
+   "address": "5570 Crawford Drive, Bethlehem, PA",
+   "lat": 40.6745839,
+   "lng": -75.3874211,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-694-9200",
+   "website": "https://restaurants.subway.com/united-states/pa/bethlehem/5570-crawford-drive",
+   "openingHours": "08:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665803"
+  },
+  {
+   "id": "node/5876415696",
+   "name": "Subway",
+   "address": "1882 Catasauqua Road, Allentown, PA",
+   "lat": 40.6397277,
+   "lng": -75.4297391,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-264-1702",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/1882-catasaqua-road",
+   "openingHours": "Mo-Th 08:00-21:00; Fr-Sa 08:00-21:30; Su 08:30-20:30",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5876415696"
+  },
+  {
+   "id": "node/5927886793",
+   "name": "Subway",
+   "address": "4753 Freemansburg Avenue, Easton, PA",
+   "lat": 40.6506939,
+   "lng": -75.2948548,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610 849 2343",
+   "website": "https://restaurants.subway.com/united-states/pa/easton/4753-freemansburg-avenue",
+   "openingHours": "Mo-Th 08:00-21:00; Fr-Sa 08:00-21:30",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5927886793"
+  },
+  {
+   "id": "node/6914168874",
+   "name": "Subway",
+   "address": "755 Hanover Avenue, Allentown, PA",
+   "lat": 40.6165581,
+   "lng": -75.4438023,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-433-7699",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/755-hanover-ave",
+   "openingHours": "08:30-21:30",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6914168874"
+  },
+  {
+   "id": "node/7685015199",
+   "name": "Subway",
+   "address": "2180 MacArthur Road, Whitehall, PA",
+   "lat": 40.6367894,
+   "lng": -75.4917674,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-433-2404",
+   "website": "https://restaurants.subway.com/united-states/pa/whitehall/2180-macarthur-road",
+   "openingHours": "08:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685015199"
+  },
+  {
+   "id": "node/7937971901",
+   "name": "Subway",
+   "address": "1328 Chestnut Street, Emmaus, PA",
+   "lat": 40.5265938,
+   "lng": -75.5096335,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-966-3630",
+   "website": "https://restaurants.subway.com/united-states/pa/emmaus/1328-chestnut-street",
+   "openingHours": "08:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971901"
+  },
+  {
+   "id": "node/11515467051",
+   "name": "Subway",
+   "address": "350 South Best Avenue, Walnutport, PA",
+   "lat": 40.7528356,
+   "lng": -75.5915755,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-760-0777",
+   "website": "https://restaurants.subway.com/united-states/pa/walnutport/350-d-best-avenue",
+   "openingHours": "09:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11515467051"
+  },
+  {
+   "id": "node/11684849361",
+   "name": "Subway",
+   "address": "1611 Lehigh Street, Allentown, PA",
+   "lat": 40.5779175,
+   "lng": -75.479314,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-797-7515",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/1611-lehigh-st",
+   "openingHours": "Mo-Sa 08:30-21:30; Su 08:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11684849361"
+  },
+  {
+   "id": "node/11711477870",
+   "name": "Subway",
+   "address": "7150 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5498924,
+   "lng": -75.5981225,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-395-9353",
+   "website": "https://restaurants.subway.com/united-states/pa/trexlertown/7150-hamilton-blvd",
+   "openingHours": "08:30-22:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11711477870"
+  },
+  {
+   "id": "node/11893016957",
+   "name": "Subway",
+   "address": "7801 Glenlivet Drive West, Fogelsville, PA",
+   "lat": 40.590999,
+   "lng": -75.6314793,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-841-8061",
+   "website": "https://restaurants.subway.com/united-states/pa/fogelsville/7801-glenlivet-west-drive",
+   "openingHours": "08:30-22:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11893016957"
+  },
+  {
+   "id": "way/53841538",
+   "name": "Subway",
+   "address": "1537 North Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.6127701,
+   "lng": -75.5323513,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-434-0505",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/1537-north-cedar-crest-blvd",
+   "openingHours": "Mo-Fr 06:00-23:00; Sa 09:00-23:00; Su 09:00-21:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/53841538"
+  },
+  {
+   "id": "way/263901544",
+   "name": "Subway",
+   "address": "",
+   "lat": 40.578176,
+   "lng": -75.5293348,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/subway",
+   "openingHours": null,
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/263901544"
+  },
+  {
+   "id": "way/610929644",
+   "name": "Subway",
+   "address": "1208 South 4th Street, Allentown, PA",
+   "lat": 40.5898041,
+   "lng": -75.4603003,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-798-7878",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/1208-s-4th-st",
+   "openingHours": "Mo-Th 08:00-22:00; Fr 08:00-24:00; Sa 08:00-22:00; Su 08:00-24:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610929644"
+  },
+  {
+   "id": "way/860920410",
+   "name": "Subway",
+   "address": "3830 Dorney Park Road, Allentown, PA",
+   "lat": 40.5801384,
+   "lng": -75.5337876,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-391-7757",
+   "website": "https://restaurants.subway.com/united-states/pa/allentown/3830-dorney-park-road",
+   "openingHours": "11:00-19:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/860920410"
+  },
+  {
+   "id": "way/1355129459",
+   "name": "Subway",
+   "address": "5626 PA 145, Laurys Station, PA",
+   "lat": 40.7256787,
+   "lng": -75.5333772,
+   "types": [
+    "fast_food",
+    "sandwich",
+    "takeaway"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-261-1010",
+   "website": "https://restaurants.subway.com/united-states/pa/laurys-station/5626-rt-145",
+   "openingHours": "Mo-Fr 08:00-23:00; Sa 09:00-23:00; Su 10:00-20:00",
+   "brand": "Subway",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1355129459"
+  },
+  {
+   "id": "node/7685098572",
+   "name": "Sumo Sushi and Japanese Restaurant",
+   "address": "3100 Tilghman Street, Allentown, PA",
+   "lat": 40.5960477,
+   "lng": -75.526573,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7685098572"
+  },
+  {
+   "id": "way/508225601",
+   "name": "Sunrise Diner",
+   "address": "1401 South 4th Street, Allentown, PA",
+   "lat": 40.5872371,
+   "lng": -75.4595589,
+   "types": [
+    "restaurant",
+    "american",
+    "greek"
+   ],
+   "cuisine": [
+    "american",
+    "greek"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/508225601"
+  },
+  {
+   "id": "way/1278058461",
+   "name": "Sunset Grille/Bar",
+   "address": "6751 Ruppsville Road, Allentown, PA",
+   "lat": 40.5803216,
+   "lng": -75.6011498,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103959622",
+   "website": "https://www.sunset-grille.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1278058461"
+  },
+  {
+   "id": "way/846606184",
+   "name": "Superior",
+   "address": "102 East Main Street, Emmaus, PA",
+   "lat": 40.5422573,
+   "lng": -75.4856776,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109655750",
+   "website": "https://superiorrestaurantpa.com/",
+   "openingHours": "Su-We 06:00-22:00;Th 06:00-23:00;Fr-Sa 06:00-23:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846606184"
+  },
+  {
+   "id": "way/859155779",
+   "name": "Suppertime",
+   "address": "",
+   "lat": 40.5796919,
+   "lng": -75.5317116,
+   "types": [
+    "fast_food",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/suppertime",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/859155779"
+  },
+  {
+   "id": "way/1410093617",
+   "name": "Susquehanna Street Diner",
+   "address": "1701 East Susquehanna Street, Allentown, PA",
+   "lat": 40.5946229,
+   "lng": -75.4174854,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16106630099",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1410093617"
+  },
+  {
+   "id": "way/846600529",
+   "name": "Swadee Thai House",
+   "address": "302 Main Street, Emmaus, PA",
+   "lat": 40.5357226,
+   "lng": -75.4900061,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104218079",
+   "website": "http://www.swadeethaihouse.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846600529"
+  },
+  {
+   "id": "node/13025819330",
+   "name": "Sweet Revenge",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6146314,
+   "lng": -75.3596042,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819330"
+  },
+  {
+   "id": "way/846599610",
+   "name": "Switchback Pizza Company",
+   "address": "525 Jubilee Street, Emmaus, PA",
+   "lat": 40.5331486,
+   "lng": -75.4935797,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109280641",
+   "website": "https://www.switchbackpizza.com/#/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846599610"
+  },
+  {
+   "id": "way/1524515042",
+   "name": "Syb's West End Deli",
+   "address": "2151 West Liberty Street, Allentown, PA",
+   "lat": 40.6008793,
+   "lng": -75.5059919,
+   "types": [
+    "restaurant",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104343882",
+   "website": "https://www.facebook.com/sybsdeli/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1524515042"
+  },
+  {
+   "id": "node/6904198062",
+   "name": "Syriana Mediterranean Grill",
+   "address": "1916 Hanover Avenue, Allentown, PA",
+   "lat": 40.6214217,
+   "lng": -75.4268092,
+   "types": [
+    "restaurant",
+    "mediterranean"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6904198062"
+  },
+  {
+   "id": "way/198872056",
+   "name": "Taco Bell",
+   "address": "2585 Easton Avenue, Bethlehem, PA",
+   "lat": 40.6447234,
+   "lng": -75.3465418,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-317-9644",
+   "website": "https://locations.tacobell.com/pa/bethlehem/2585-easton-avenue.html",
+   "openingHours": "Mo-Sa 08:00-01:00; Su 10:00-01:00",
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872056"
+  },
+  {
+   "id": "way/278759991",
+   "name": "Taco Bell",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5545867,
+   "lng": -75.4906078,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-966-5144",
+   "website": "https://locations.tacobell.com/pa/allentown/3380-lehigh-street.html",
+   "openingHours": null,
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278759991"
+  },
+  {
+   "id": "way/594652874",
+   "name": "Taco Bell",
+   "address": "506 Old Main Street, Walnutport, PA",
+   "lat": 40.7578912,
+   "lng": -75.5933026,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-760-3049",
+   "website": "https://locations.tacobell.com/pa/walnutport/506-old-main-street.html",
+   "openingHours": "08:00-24:00",
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/594652874"
+  },
+  {
+   "id": "way/888903926",
+   "name": "Taco Bell",
+   "address": "1102 Airport Road, Allentown, PA",
+   "lat": 40.6270372,
+   "lng": -75.4429263,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-841-1330",
+   "website": "https://locations.tacobell.com/pa/allentown/1102-1122-airport-rd.html",
+   "openingHours": null,
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/888903926"
+  },
+  {
+   "id": "way/1281328301",
+   "name": "Taco Bell",
+   "address": "5374 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5624256,
+   "lng": -75.5618147,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16104429662",
+   "website": "https://locations.tacobell.com/pa/allentown/5374-hamilton-blvd.html",
+   "openingHours": null,
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1281328301"
+  },
+  {
+   "id": "way/1393207479",
+   "name": "Taco Bell",
+   "address": "301 Cooper Street, Allentown, PA",
+   "lat": 40.5796331,
+   "lng": -75.4548487,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16108711601",
+   "website": "https://locations.tacobell.com/pa/allentown/301-cooper-st.html",
+   "openingHours": null,
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1393207479"
+  },
+  {
+   "id": "way/1453740675",
+   "name": "Taco Bell",
+   "address": "248 North PA Route 100, Breinigsville, PA",
+   "lat": 40.5765532,
+   "lng": -75.6221939,
+   "types": [
+    "fast_food",
+    "tex-mex",
+    "takeaway"
+   ],
+   "cuisine": [
+    "tex-mex"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-530-8888",
+   "website": "https://locations.tacobell.com/pa/breinigsville/248-north-pa-route-100.html",
+   "openingHours": "Mo-Th 07:00-01:00; Fr-Sa 07:00-02:00; Su 07:00-01:00",
+   "brand": "Taco Bell",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1453740675"
+  },
+  {
+   "id": "node/6938558558",
+   "name": "Tacos El Jalapeno",
+   "address": "1033 North 6th Street, Whitehall, PA",
+   "lat": 40.6178757,
+   "lng": -75.4773211,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6938558558"
+  },
+  {
+   "id": "node/6932056535",
+   "name": "Tacos y Tequila",
+   "address": "530 Hamilton Street, Allentown, PA",
+   "lat": 40.6028136,
+   "lng": -75.4689925,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6932056535"
+  },
+  {
+   "id": "node/4886201642",
+   "name": "Tapas on Main",
+   "address": "500 Main Street, Bethlehem, PA",
+   "lat": 40.6207598,
+   "lng": -75.3818538,
+   "types": [
+    "restaurant",
+    "spanish",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "spanish"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-868-8903",
+   "website": "https://www.tapasonmain.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4886201642"
+  },
+  {
+   "id": "way/1276702330",
+   "name": "Taphouse & Eatery by McCall Collective",
+   "address": "7743 Hamilton Boulevard, Breinigsville, PA",
+   "lat": 40.5470749,
+   "lng": -75.6084437,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14847359688",
+   "website": "https://www.mccallcollectivebrewing.com/hamilton-menu",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1276702330"
+  },
+  {
+   "id": "node/6943158030",
+   "name": "Taqueria Los Amigos",
+   "address": "515 North 7th Street, Allentown, PA",
+   "lat": 40.6096876,
+   "lng": -75.4750579,
+   "types": [
+    "fast_food",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943158030"
+  },
+  {
+   "id": "node/13127931682",
+   "name": "Taste of China",
+   "address": "5531 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.561878,
+   "lng": -75.5649729,
+   "types": [
+    "fast_food",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13127931682"
+  },
+  {
+   "id": "node/11892215606",
+   "name": "Tasty Bitez",
+   "address": "",
+   "lat": 40.6304485,
+   "lng": -75.4803432,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11892215606"
+  },
+  {
+   "id": "node/6206792387",
+   "name": "Tasty China",
+   "address": "134 West 4th Street, Bethlehem, PA",
+   "lat": 40.6102482,
+   "lng": -75.3813451,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6206792387"
+  },
+  {
+   "id": "node/13229662090",
+   "name": "Tasty Dish Chinese Street Food",
+   "address": "",
+   "lat": 40.5867644,
+   "lng": -75.341524,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14848513460",
+   "website": "https://www.tastydishpa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13229662090"
+  },
+  {
+   "id": "way/1273969095",
+   "name": "Taylor House Brewing",
+   "address": "76 Lehigh Street, Catasauqua, PA",
+   "lat": 40.6474284,
+   "lng": -75.4675764,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "http://taylorhousebrewing.com/",
+   "openingHours": "Th 16:00-21:00; Fr-Sa 14:00-22:00; Su 14:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1273969095"
+  },
+  {
+   "id": "node/4100814089",
+   "name": "Taylor Roasted CoffeeHouse",
+   "address": "1924 Main Street",
+   "lat": 40.6894886,
+   "lng": -75.4988874,
+   "types": [
+    "cafe",
+    "coffee_shop"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 267 405 2326",
+   "website": "taylorroastedcoffeehouse.com",
+   "openingHours": "Mo-Sa 09:00-19:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4100814089"
+  },
+  {
+   "id": "way/1386045371",
+   "name": "Teresas' Italian Restaurant & Pizzeria",
+   "address": "6561 Tilghman Street, Allentown, PA",
+   "lat": 40.5895423,
+   "lng": -75.6034442,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14842854354",
+   "website": "https://www.teresasitalianrestaurantpizzeria.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1386045371"
+  },
+  {
+   "id": "node/12691825335",
+   "name": "Teriyaki Madness",
+   "address": "2659 MacArthur Road, Whitehall, PA",
+   "lat": 40.6482011,
+   "lng": -75.4924406,
+   "types": [
+    "fast_food",
+    "japanese",
+    "takeaway"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Teriyaki Madness",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12691825335"
+  },
+  {
+   "id": "way/278759469",
+   "name": "Texas Roadhouse",
+   "address": "6268 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5557663,
+   "lng": -75.5789065,
+   "types": [
+    "restaurant",
+    "steak_house"
+   ],
+   "cuisine": [
+    "steak_house"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+16103952611",
+   "website": "https://www.texasroadhouse.com/locations/340-trexlertownpa",
+   "openingHours": null,
+   "brand": "Texas Roadhouse",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278759469"
+  },
+  {
+   "id": "way/349643371",
+   "name": "Texas Roadhouse",
+   "address": "4463 Southmont Way, Easton, PA",
+   "lat": 40.6545046,
+   "lng": -75.2875203,
+   "types": [
+    "restaurant",
+    "steak_house"
+   ],
+   "cuisine": [
+    "steak_house"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+1 610-515-0225",
+   "website": "https://www.texasroadhouse.com/locations/184-bethlehempa",
+   "openingHours": "Mo-Th 16:00-22:00; Fr 16:00-23:00; Sa 12:00-23:00; Su 12:00-22:00",
+   "brand": "Texas Roadhouse",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/349643371"
+  },
+  {
+   "id": "way/889971204",
+   "name": "TG Countryside",
+   "address": "5130 Chestnut Street, Emmaus, PA",
+   "lat": 40.498395,
+   "lng": -75.5284562,
+   "types": [
+    "ice_cream",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109282800",
+   "website": "https://tgcountryside.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/889971204"
+  },
+  {
+   "id": "way/225871973",
+   "name": "TGI Fridays",
+   "address": "4402 Southmont Way, Easton, PA",
+   "lat": 40.6551439,
+   "lng": -75.2848501,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-923-7855",
+   "website": "https://locations.tgifridays.com/pa/easton/4402-southmont-way.html",
+   "openingHours": "Mo-Th,Su 10:45-23:00; Fr,Sa 10:45-24:00",
+   "brand": "TGI Fridays",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/225871973"
+  },
+  {
+   "id": "node/9401055489",
+   "name": "Thai Avenue Restaurant",
+   "address": "4791 Tilghman Street, Allentown, PA",
+   "lat": 40.5901277,
+   "lng": -75.562274,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103519496",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9401055489"
+  },
+  {
+   "id": "node/6206301361",
+   "name": "Thai Kitchen",
+   "address": "347 Broadway, Bethlehem, PA",
+   "lat": 40.6094605,
+   "lng": -75.3843508,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6206301361"
+  },
+  {
+   "id": "node/10088688015",
+   "name": "Thai Origin",
+   "address": "4686 Broadway, Allentown, PA",
+   "lat": 40.588562,
+   "lng": -75.5609714,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10088688015"
+  },
+  {
+   "id": "node/4886201640",
+   "name": "Thai Thai II",
+   "address": "509 Main Street, Bethlehem, PA",
+   "lat": 40.6209054,
+   "lng": -75.382217,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-868-1919",
+   "website": "https://www.thaithai2.com/",
+   "openingHours": "Su-Th 16:00-20:00; Fr,Sa 15:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4886201640"
+  },
+  {
+   "id": "node/9875328298",
+   "name": "The Bacon Strip",
+   "address": "18 North 2nd Street, Coplay, PA",
+   "lat": 40.6732226,
+   "lng": -75.4920261,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9875328298"
+  },
+  {
+   "id": "node/9726460759",
+   "name": "The Bath Exchange",
+   "address": "204 West Main Street, Bath, PA",
+   "lat": 40.7258087,
+   "lng": -75.3944993,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-282-3366",
+   "website": "https://thebathexchange.com",
+   "openingHours": "Mo-Su 12:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9726460759"
+  },
+  {
+   "id": "way/576405991",
+   "name": "The Bayou",
+   "address": "702 Hawthorne Road, Bethlehem, PA",
+   "lat": 40.6230369,
+   "lng": -75.3646109,
+   "types": [
+    "restaurant",
+    "american",
+    "southern",
+    "alcohol",
+    "takeaway",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "american",
+    "southern",
+    "alcohol"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104196669",
+   "website": "https://datbayoulv.com/thebayoubethlehem",
+   "openingHours": "Mo-Su 11:00-7:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/576405991"
+  },
+  {
+   "id": "node/677131251",
+   "name": "The Bookstore",
+   "address": "336",
+   "lat": 40.610725,
+   "lng": -75.377251,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/677131251"
+  },
+  {
+   "id": "node/5675639654",
+   "name": "The Brick",
+   "address": "1 West Broad Street, Bethlehem, PA",
+   "lat": 40.6220444,
+   "lng": -75.3790019,
+   "types": [
+    "restaurant",
+    "pizza",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 1141",
+   "website": "https://www.thebrickpa.com/",
+   "openingHours": "Mo,We,Su 11:00-22:00; Th-Sa 11:00-23:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5675639654"
+  },
+  {
+   "id": "way/1313139335",
+   "name": "The Burger Shack",
+   "address": "2011 North 1st Avenue, Whitehall, PA",
+   "lat": 40.6471799,
+   "lng": -75.4752439,
+   "types": [
+    "restaurant",
+    "burger"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104432077",
+   "website": "https://theburgershackpa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1313139335"
+  },
+  {
+   "id": "node/4886201645",
+   "name": "The Cafe",
+   "address": "221 West Broad Street, Bethlehem, PA",
+   "lat": 40.6222337,
+   "lng": -75.3863718,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-866-1686",
+   "website": "https://thecafebethlehempa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4886201645"
+  },
+  {
+   "id": "way/1349146624",
+   "name": "The Catty Corner Neighborhood Pub and Pie",
+   "address": "301 Mulberry Street, Catasauqua, PA",
+   "lat": 40.652093,
+   "lng": -75.4685532,
+   "types": [
+    "pub",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104432284",
+   "website": "https://cattycornerpub.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1349146624"
+  },
+  {
+   "id": "node/11892215605",
+   "name": "The Cheesecake Factory",
+   "address": "",
+   "lat": 40.6303979,
+   "lng": -75.4808092,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "The Cheesecake Factory",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11892215605"
+  },
+  {
+   "id": "node/13043140459",
+   "name": "The Clubhouse Grille",
+   "address": "400 Illick's Mill Road, Bethlehem, PA",
+   "lat": 40.643003,
+   "lng": -75.3862143,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13043140459"
+  },
+  {
+   "id": "way/1032079985",
+   "name": "The Columbian Home",
+   "address": "1519 Greenleaf Street, Allentown, PA",
+   "lat": 40.6106971,
+   "lng": -75.4953749,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104326333",
+   "website": "https://thecolumbianhome.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1032079985"
+  },
+  {
+   "id": "node/7986136231",
+   "name": "The Crust Pizzeria And Restaurant",
+   "address": "",
+   "lat": 40.5578948,
+   "lng": -75.4837501,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7986136231"
+  },
+  {
+   "id": "node/2797275499",
+   "name": "The Cup",
+   "address": "2 Farrington Square, Bethlehem, PA",
+   "lat": 40.6096423,
+   "lng": -75.3785947,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2797275499"
+  },
+  {
+   "id": "way/1503398826",
+   "name": "The Fairgrounds Hotel",
+   "address": "",
+   "lat": 40.6031373,
+   "lng": -75.4956993,
+   "types": [
+    "restaurant",
+    "seafood"
+   ],
+   "cuisine": [
+    "seafood"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1503398826"
+  },
+  {
+   "id": "node/5664659530",
+   "name": "The Flying Egg",
+   "address": "451 Main Street, Bethlehem, PA",
+   "lat": 40.6203172,
+   "lng": -75.3822657,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 625 2515",
+   "website": "https://www.theflyingeggbethlehem.com",
+   "openingHours": "Mo-Fr 07:00-14:00; Sa-Su 08:00-15:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5664659530"
+  },
+  {
+   "id": "node/8730005207",
+   "name": "The Flying V Poutinerie",
+   "address": "201 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6121397,
+   "lng": -75.3758041,
+   "types": [
+    "restaurant",
+    "poutine",
+    "takeaway",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "poutine"
+   ],
+   "dietary": [
+    "gluten_free"
+   ],
+   "priceLevel": null,
+   "phone": "+1 610 419 2530",
+   "website": "https://www.flyingvpoutinerie.com/",
+   "openingHours": "We 16:00-21:00; Th-Fr 12:00-21:00; Sa 11:00-21:00; Su 12:00-17:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/8730005207"
+  },
+  {
+   "id": "node/5821469652",
+   "name": "The Foundry Pub & Beerhall",
+   "address": "",
+   "lat": 40.5645639,
+   "lng": -75.56695,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5821469652"
+  },
+  {
+   "id": "node/12704917595",
+   "name": "The Garden Grille & Bar",
+   "address": "1787 Airport Road, Allentown, PA",
+   "lat": 40.6380779,
+   "lng": -75.4336478,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12704917595"
+  },
+  {
+   "id": "way/1187808689",
+   "name": "The Gin Mill and Grille",
+   "address": "1750 Main Street, Northampton, PA",
+   "lat": 40.6862621,
+   "lng": -75.4973314,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1187808689"
+  },
+  {
+   "id": "node/1339057454",
+   "name": "The Goosemen",
+   "address": "102 West 4th Street, Bethlehem",
+   "lat": 40.610295,
+   "lng": -75.3799432,
+   "types": [
+    "fast_food",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1339057454"
+  },
+  {
+   "id": "node/13477907745",
+   "name": "The Green House Tea Room",
+   "address": "403 Cherokee Street, Bethlehem, PA",
+   "lat": 40.6106412,
+   "lng": -75.3862925,
+   "types": [
+    "cafe",
+    "tea"
+   ],
+   "cuisine": [
+    "tea"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13477907745"
+  },
+  {
+   "id": "way/223898228",
+   "name": "The Inside Scoop",
+   "address": "301 North 3rd Street, Coopersburg, PA",
+   "lat": 40.5145581,
+   "lng": -75.3846555,
+   "types": [
+    "ice_cream",
+    "drive_through"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102821955",
+   "website": "https://theinsidescoop.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/223898228"
+  },
+  {
+   "id": "node/13885843744",
+   "name": "The Jetport Bar & Lounge",
+   "address": "3400 Airport Road, Allentown, PA",
+   "lat": 40.6576436,
+   "lng": -75.4270277,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13885843744"
+  },
+  {
+   "id": "node/5675639655",
+   "name": "The Joint",
+   "address": "77 West Broad Street, Bethlehem, PA",
+   "lat": 40.6218694,
+   "lng": -75.3809159,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 9237",
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5675639655"
+  },
+  {
+   "id": "node/11892215598",
+   "name": "The Joint Coffee Co.",
+   "address": "",
+   "lat": 40.6294814,
+   "lng": -75.4820346,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11892215598"
+  },
+  {
+   "id": "node/831649299",
+   "name": "The Melting Pot",
+   "address": "1 East Broad Street, Bethlehem, PA",
+   "lat": 40.6224418,
+   "lng": -75.378052,
+   "types": [
+    "restaurant",
+    "fondue"
+   ],
+   "cuisine": [
+    "fondue"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-484-241-4939",
+   "website": "https://www.meltingpot.com/bethlehem/welcome",
+   "openingHours": "Mo-Th 17:00-22:00; Fr 17:00-23:00; Sa 16:00-23:00; Su 16:00-21:00",
+   "brand": "The Melting Pot",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831649299"
+  },
+  {
+   "id": "node/7937971892",
+   "name": "The Mix Bartending School",
+   "address": "",
+   "lat": 40.5274436,
+   "lng": -75.5102946,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7937971892"
+  },
+  {
+   "id": "node/1341219760",
+   "name": "The Nest Bar & Grille",
+   "address": "601 East 4th Street, Bethlehem, PA",
+   "lat": 40.6107698,
+   "lng": -75.3705236,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/1341219760"
+  },
+  {
+   "id": "way/607941211",
+   "name": "The New Santiago’s Restaurant",
+   "address": "125 South 3rd Street, Coopersburg, PA",
+   "lat": 40.5085218,
+   "lng": -75.3856374,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14848190311",
+   "website": "https://www.facebook.com/santiagosdinercoopersburg",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/607941211"
+  },
+  {
+   "id": "way/384115320",
+   "name": "The New Schnecksville Diner",
+   "address": "4527 PA 309, Schnecksville, PA",
+   "lat": 40.667152,
+   "lng": -75.6062158,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-760-3018",
+   "website": "https://schnecksvillediner.shop/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/384115320"
+  },
+  {
+   "id": "way/94395437",
+   "name": "The Olive Garden",
+   "address": "715 Grape Street, Whitehall, PA",
+   "lat": 40.6355358,
+   "lng": -75.4760878,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": 2,
+   "phone": "+16102666777",
+   "website": "https://www.olivegarden.com/locations/pa/whitehall/whitehall/1425",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/94395437"
+  },
+  {
+   "id": "node/11974830477",
+   "name": "The Orchid Steakhouse",
+   "address": "322 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6119678,
+   "lng": -75.3734306,
+   "types": [
+    "restaurant",
+    "steak_house"
+   ],
+   "cuisine": [
+    "steak_house"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16106259222",
+   "website": "https://www.orchidstk.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11974830477"
+  },
+  {
+   "id": "way/346382089",
+   "name": "The Original Tavern House",
+   "address": "605 Main Street, Hellertown, PA",
+   "lat": 40.5779655,
+   "lng": -75.340513,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/346382089"
+  },
+  {
+   "id": "node/831824198",
+   "name": "The Other Fish",
+   "address": "59 East Broad Street, Bethlehem, PA",
+   "lat": 40.6224114,
+   "lng": -75.3766517,
+   "types": [
+    "restaurant",
+    "japanese"
+   ],
+   "cuisine": [
+    "japanese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-484-821-1370",
+   "website": "http://www.dineindie.com/TheOtherFish",
+   "openingHours": "Mo-Fr 11:30-14:00,Mo-Th 17:00-22:00, Fr-Sa 17:00-23:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/831824198"
+  },
+  {
+   "id": "node/6188314585",
+   "name": "The People's Kitchen",
+   "address": "639 Linden Street, Bethlehem, PA",
+   "lat": 40.6233672,
+   "lng": -75.3706899,
+   "types": [
+    "cafe",
+    "diner",
+    "pancake",
+    "american",
+    "sandwich",
+    "breakfast",
+    "coffee_shop",
+    "grill"
+   ],
+   "cuisine": [
+    "diner",
+    "pancake",
+    "american",
+    "sandwich",
+    "breakfast",
+    "coffee_shop",
+    "grill"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": "Mo-Su 06:00-15:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6188314585"
+  },
+  {
+   "id": "node/9319487782",
+   "name": "The Red Tomato Pizzeria",
+   "address": "3640 Route 309, Orefield, PA",
+   "lat": 40.6474501,
+   "lng": -75.5953876,
+   "types": [
+    "restaurant",
+    "pizza",
+    "takeaway"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 398 8999",
+   "website": "https://theredtomatopizzeria.com/home",
+   "openingHours": "Su-Th 11:00-21:00; Fr,Sa 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9319487782"
+  },
+  {
+   "id": "node/12682720771",
+   "name": "The Steel Pub Sports Bar and Grille",
+   "address": "320 East 1st Street, Bethlehem, PA",
+   "lat": 40.6141182,
+   "lng": -75.3736935,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720771"
+  },
+  {
+   "id": "way/204564730",
+   "name": "The Sun Inn",
+   "address": "564 Main Street, Bethlehem, PA",
+   "lat": 40.6219245,
+   "lng": -75.3817321,
+   "types": [
+    "pub",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-419-8600",
+   "website": "https://suninnbethlehem.org/",
+   "openingHours": "We-Su 12:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/204564730"
+  },
+  {
+   "id": "way/43567720",
+   "name": "The Tally Ho",
+   "address": "205 West 4th Street, Bethlehem, PA",
+   "lat": 40.6105615,
+   "lng": -75.3818042,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/43567720"
+  },
+  {
+   "id": "node/3924684308",
+   "name": "The Tap Room",
+   "address": "437 Main Street, Bethlehem, PA",
+   "lat": 40.6202388,
+   "lng": -75.3822551,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3924684308"
+  },
+  {
+   "id": "node/12682720756",
+   "name": "The Taste Smokers",
+   "address": "318 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6119606,
+   "lng": -75.373643,
+   "types": [
+    "restaurant",
+    "barbecue"
+   ],
+   "cuisine": [
+    "barbecue"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720756"
+  },
+  {
+   "id": "way/1301666387",
+   "name": "The Trapp Door Gastropub",
+   "address": "4226 Chestnut Street, Emmaus, PA",
+   "lat": 40.5158838,
+   "lng": -75.5239294,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109655225",
+   "website": "https://thetrappdoorgastropub.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1301666387"
+  },
+  {
+   "id": "node/13759012971",
+   "name": "The Udder Bar",
+   "address": "",
+   "lat": 40.6035749,
+   "lng": -75.4998231,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13759012971"
+  },
+  {
+   "id": "node/5807665765",
+   "name": "The Weaversville Inn",
+   "address": "",
+   "lat": 40.6887831,
+   "lng": -75.4522394,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5807665765"
+  },
+  {
+   "id": "way/596139611",
+   "name": "The West End",
+   "address": "750 North West End Boulevard, Quakertown, PA",
+   "lat": 40.4632082,
+   "lng": -75.3697408,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 267-347-4003",
+   "website": "https://www.thewestendpa.com/",
+   "openingHours": "Mo 15:00-24:00; Tu-Th 11:00-24:00; Fr,Sa 11:00-25:00, Su 10:00-23:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/596139611"
+  },
+  {
+   "id": "node/6345685676",
+   "name": "The Wise Bean",
+   "address": "634 North New Street, Bethlehem, PA",
+   "lat": 40.6230722,
+   "lng": -75.3782563,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6345685676"
+  },
+  {
+   "id": "way/554002085",
+   "name": "The Wooden Match",
+   "address": "61 West Lehigh Street, Bethlehem, PA",
+   "lat": 40.6165183,
+   "lng": -75.3823929,
+   "types": [
+    "pub",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16108651777",
+   "website": "https://www.thewoodenmatch.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/554002085"
+  },
+  {
+   "id": "way/94395431",
+   "name": "Thirsty Turtle",
+   "address": "1410 Grape Street, Whitehall, PA",
+   "lat": 40.6325425,
+   "lng": -75.4838817,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104347600",
+   "website": "https://keystonepub.com/whitehall",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/94395431"
+  },
+  {
+   "id": "node/3566467592",
+   "name": "This is Burritos",
+   "address": "1808 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6377411,
+   "lng": -75.348812,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3566467592"
+  },
+  {
+   "id": "way/859161600",
+   "name": "Tidal Wave Café",
+   "address": "",
+   "lat": 40.5792907,
+   "lng": -75.5290402,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.dorneypark.com/play/drinks-dining/tidal-wave-cafe",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/859161600"
+  },
+  {
+   "id": "node/7975349673",
+   "name": "Tijuana Tacos Mexican Restaurant",
+   "address": "",
+   "lat": 40.5492814,
+   "lng": -75.4911642,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7975349673"
+  },
+  {
+   "id": "node/5851415242",
+   "name": "Tim Hortons",
+   "address": "701 Hamilton Street, Allentown, PA",
+   "lat": 40.6021353,
+   "lng": -75.4724299,
+   "types": [
+    "cafe",
+    "coffee_shop",
+    "takeaway",
+    "delivery"
+   ],
+   "cuisine": [
+    "coffee_shop"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 484-273-4508",
+   "website": null,
+   "openingHours": "Mo-Fr 07:30-14:00",
+   "brand": "Tim Hortons",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5851415242"
+  },
+  {
+   "id": "node/11522499021",
+   "name": "Tinto Tapas & Pasta",
+   "address": "1028 Broadway, Fountain Hill, PA",
+   "lat": 40.6025591,
+   "lng": -75.3919501,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11522499021"
+  },
+  {
+   "id": "way/610929629",
+   "name": "Tipico",
+   "address": "410 West Emaus Avenue, Allentown, PA",
+   "lat": 40.5773171,
+   "lng": -75.4545665,
+   "types": [
+    "restaurant",
+    "dominican"
+   ],
+   "cuisine": [
+    "dominican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/610929629"
+  },
+  {
+   "id": "node/6917211474",
+   "name": "Tipsy's Bar & Lounge",
+   "address": "462 Union Boulevard, Allentown, PA",
+   "lat": 40.6202278,
+   "lng": -75.4525906,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6917211474"
+  },
+  {
+   "id": "node/5808274491",
+   "name": "Tony's Pizza",
+   "address": "",
+   "lat": 40.5103327,
+   "lng": -75.3917311,
+   "types": [
+    "restaurant",
+    "pizza",
+    "italian"
+   ],
+   "cuisine": [
+    "pizza",
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5808274491"
+  },
+  {
+   "id": "node/7095996813",
+   "name": "Top Cut",
+   "address": "",
+   "lat": 40.5595008,
+   "lng": -75.4100935,
+   "types": [
+    "restaurant",
+    "steak_house"
+   ],
+   "cuisine": [
+    "steak_house"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7095996813"
+  },
+  {
+   "id": "node/5678995194",
+   "name": "Torré",
+   "address": "",
+   "lat": 40.5592126,
+   "lng": -75.4105713,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5678995194"
+  },
+  {
+   "id": "node/4885851952",
+   "name": "Touch Thai",
+   "address": "549 Main Street, Bethlehem, PA",
+   "lat": 40.6217147,
+   "lng": -75.3821667,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "http://www.touchthaibethlehem.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4885851952"
+  },
+  {
+   "id": "node/6221940190",
+   "name": "Tre Scalini Ristorante",
+   "address": "221 East Broad Street, Bethlehem, PA",
+   "lat": 40.6223747,
+   "lng": -75.3723745,
+   "types": [
+    "restaurant",
+    "italian"
+   ],
+   "cuisine": [
+    "italian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6221940190"
+  },
+  {
+   "id": "way/276428439",
+   "name": "Tri-Boro Sportsman Club",
+   "address": "",
+   "lat": 40.6939606,
+   "lng": -75.5082946,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/276428439"
+  },
+  {
+   "id": "node/3270667571",
+   "name": "Tri-Boro Sportsmen",
+   "address": "",
+   "lat": 40.693902,
+   "lng": -75.508357,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3270667571"
+  },
+  {
+   "id": "way/448276224",
+   "name": "Trivet",
+   "address": "4549 Tilghman Street, Allentown, PA",
+   "lat": 40.5903438,
+   "lng": -75.5561352,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16103983886",
+   "website": "https://www.trivetdiner.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/448276224"
+  },
+  {
+   "id": "way/278756638",
+   "name": "Trivet's",
+   "address": "4102 Chestnut Street, Emmaus, PA",
+   "lat": 40.5184466,
+   "lng": -75.5220762,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109652838",
+   "website": "https://www.trivetdiner.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278756638"
+  },
+  {
+   "id": "node/12709754715",
+   "name": "Tropical Smoothie Cafe",
+   "address": "2411 Schoenersville Road, Bethlehem, PA",
+   "lat": 40.6424023,
+   "lng": -75.4036624,
+   "types": [
+    "fast_food",
+    "juice",
+    "takeaway"
+   ],
+   "cuisine": [
+    "juice"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Tropical Smoothie Cafe",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12709754715"
+  },
+  {
+   "id": "node/6417980920",
+   "name": "True Blue Mediterranean",
+   "address": "1301 Chestnut Street, Emmaus, PA",
+   "lat": 40.5277638,
+   "lng": -75.5094952,
+   "types": [
+    "restaurant",
+    "mediterranean",
+    "takeaway",
+    "delivery",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "mediterranean"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 966 8555",
+   "website": "https://www.yourtrueblue.com/",
+   "openingHours": "Mo-Sa 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6417980920"
+  },
+  {
+   "id": "node/6932056551",
+   "name": "Tu Mundo",
+   "address": "44 North 8th Street, Allentown, PA",
+   "lat": 40.6029846,
+   "lng": -75.4743271,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6932056551"
+  },
+  {
+   "id": "node/6925915957",
+   "name": "Tu Nueva Casa",
+   "address": "223 Hamilton Street, Allentown, PA",
+   "lat": 40.6057578,
+   "lng": -75.4609611,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-609-7014",
+   "website": "https://tunuevacasarestaurantpa.com/",
+   "openingHours": "Mo-Sa 09:00-20:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6925915957"
+  },
+  {
+   "id": "node/4205769500",
+   "name": "Tulum",
+   "address": "17 West Morton Street, Bethlehem, PA",
+   "lat": 40.6099488,
+   "lng": -75.3791244,
+   "types": [
+    "restaurant",
+    "mexican"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-691-8300",
+   "website": "https://www.tulumbethmex.com/",
+   "openingHours": "Mo-Fr 11:00-21:00; Sa,Su off",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4205769500"
+  },
+  {
+   "id": "node/6219855053",
+   "name": "Tung Hing",
+   "address": "1810 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6376507,
+   "lng": -75.3484814,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6219855053"
+  },
+  {
+   "id": "node/5737375767",
+   "name": "Twisted Olive",
+   "address": "51 West Broad Street, Bethlehem, PA",
+   "lat": 40.6221362,
+   "lng": -75.3803597,
+   "types": [
+    "restaurant",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 1200",
+   "website": "https://twistedolivebethlehem.com/",
+   "openingHours": "Mo 16:00-22:00; Tu-Sa 11:30-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5737375767"
+  },
+  {
+   "id": "node/12683556839",
+   "name": "U & TEA",
+   "address": "119 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6121222,
+   "lng": -75.3763656,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12683556839"
+  },
+  {
+   "id": "node/6206301358",
+   "name": "Uncle Aldo's",
+   "address": "400 Broadway, Bethlehem, PA",
+   "lat": 40.6091311,
+   "lng": -75.3843981,
+   "types": [
+    "restaurant",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-419-4100",
+   "website": "https://order.online/store/uncle-aldo's-bethlehem-34220329",
+   "openingHours": "Mo-Th 12:00-23:00; Fr-Sa 11:00-23:00; Su 11:00-16:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6206301358"
+  },
+  {
+   "id": "node/6217721384",
+   "name": "Uncle's Caribbean Cuisine",
+   "address": "",
+   "lat": 40.6333808,
+   "lng": -75.3518018,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6217721384"
+  },
+  {
+   "id": "way/1342264625",
+   "name": "Union And Finch",
+   "address": "1528 West Union Street, Allentown, PA",
+   "lat": 40.5947761,
+   "lng": -75.487624,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1-610-432-1522",
+   "website": "https://www.unionandfinch.com/",
+   "openingHours": "Tu-Th 11:00-21:00; Fr 11:00-22:00; Sa 10:00-22:00; Su 10:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1342264625"
+  },
+  {
+   "id": "node/13025819360",
+   "name": "Urban Table",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6150968,
+   "lng": -75.3579256,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819360"
+  },
+  {
+   "id": "node/5675639656",
+   "name": "Urbano",
+   "address": "526 Main Street, Bethlehem, PA",
+   "lat": 40.6212158,
+   "lng": -75.3818315,
+   "types": [
+    "restaurant",
+    "mexican",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "mexican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 1736",
+   "website": "https://www.urbanobethlehem.com",
+   "openingHours": "Mo-Th 11:30-22:00; Fr-Sa 11:30-23:00; Su 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5675639656"
+  },
+  {
+   "id": "way/198872821",
+   "name": "Valley Family Restaurant",
+   "address": "",
+   "lat": 40.6464103,
+   "lng": -75.342355,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872821"
+  },
+  {
+   "id": "node/12682025658",
+   "name": "Valley Legends Sports Bar",
+   "address": "1061 North 6th Street, Allentown, PA",
+   "lat": 40.6190843,
+   "lng": -75.4790166,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682025658"
+  },
+  {
+   "id": "node/11515316763",
+   "name": "Valley Pizza",
+   "address": "",
+   "lat": 40.7581853,
+   "lng": -75.5936676,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11515316763"
+  },
+  {
+   "id": "way/1239209461",
+   "name": "Valley View Diner",
+   "address": "570 Nazareth Pike, Nazareth, PA",
+   "lat": 40.7136386,
+   "lng": -75.3235704,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1239209461"
+  },
+  {
+   "id": "node/9875328310",
+   "name": "Vany's Pizza",
+   "address": "123 Chestnut Street, Coplay, PA",
+   "lat": 40.6743388,
+   "lng": -75.4927095,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9875328310"
+  },
+  {
+   "id": "node/3766570505",
+   "name": "VapeMeister",
+   "address": "650 Main Street, Hellertown, PA",
+   "lat": 40.5788993,
+   "lng": -75.3409587,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3766570505"
+  },
+  {
+   "id": "way/855554983",
+   "name": "Vargtimmen King Koffee",
+   "address": "506 Chestnut Street, Emmaus, PA",
+   "lat": 40.5341907,
+   "lng": -75.4935367,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/855554983"
+  },
+  {
+   "id": "way/346382086",
+   "name": "Vassi's Drive-in",
+   "address": "1666 Main Street, Hellertown, PA",
+   "lat": 40.5940519,
+   "lng": -75.3404853,
+   "types": [
+    "fast_food",
+    "american",
+    "ice_cream",
+    "greek",
+    "burger",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "american",
+    "ice_cream",
+    "greek",
+    "burger",
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-838-1877",
+   "website": "https://www.vassisdrive-in.com/",
+   "openingHours": "Mo-Su 11:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/346382086"
+  },
+  {
+   "id": "node/5664659529",
+   "name": "Vegout Bethlehem",
+   "address": "1 East Church Street, Bethlehem, PA",
+   "lat": 40.6188276,
+   "lng": -75.3783911,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [
+    "vegan",
+    "vegetarian"
+   ],
+   "priceLevel": null,
+   "phone": "+1 610 419 0126",
+   "website": "https://vegoutbethlehem.com/",
+   "openingHours": "Mo 10:00-20:00; We-Sa 10:00-20:00; Su 08:00-15:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5664659529"
+  },
+  {
+   "id": "node/4378177580",
+   "name": "Venny's Pizza and Restaurant",
+   "address": "840 Hamilton Street, Allentown",
+   "lat": 40.6012494,
+   "lng": -75.4746975,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4378177580"
+  },
+  {
+   "id": "way/846625228",
+   "name": "Vera Cruz Tavern & Grille",
+   "address": "3883 Vera Cruz Road, Emmaus, PA",
+   "lat": 40.5057105,
+   "lng": -75.4967116,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16109671716",
+   "website": "https://www.facebook.com/Veracruz4/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/846625228"
+  },
+  {
+   "id": "node/6314874436",
+   "name": "Verona Pizza",
+   "address": "2980 Linden Street, Bethlehem, PA",
+   "lat": 40.6564368,
+   "lng": -75.3554557,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6314874436"
+  },
+  {
+   "id": "node/13059828074",
+   "name": "Vesuvio's Restaurant & Pizza",
+   "address": "1616 South 4th Street, Allentown, PA",
+   "lat": 40.5845145,
+   "lng": -75.4609129,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13059828074"
+  },
+  {
+   "id": "node/13025819353",
+   "name": "Villa Italian Kitchen",
+   "address": "77 Wind Creek Boulevard, Bethlehem, PA",
+   "lat": 40.6145422,
+   "lng": -75.3584759,
+   "types": [
+    "fast_food",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025819353"
+  },
+  {
+   "id": "way/1312300190",
+   "name": "Villa Lentini",
+   "address": "2700 Balliet Street, Schnecksville, PA",
+   "lat": 40.678494,
+   "lng": -75.5739163,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107992400",
+   "website": "https://www.villalentinimenu.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1312300190"
+  },
+  {
+   "id": "node/496347651",
+   "name": "Vinny's Pizza",
+   "address": "6750 Iroquois Trail, Allentown, PA",
+   "lat": 40.5758359,
+   "lng": -75.5983468,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-395-2300",
+   "website": "https://www.vinnyspizzapa.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/496347651"
+  },
+  {
+   "id": "way/1503028010",
+   "name": "Volpe's Sports Bar",
+   "address": "1922 West Tilghman Street, Allentown, PA",
+   "lat": 40.6045656,
+   "lng": -75.5017877,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16104350311",
+   "website": "https://volpessportsbar.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1503028010"
+  },
+  {
+   "id": "way/473385305",
+   "name": "Volpes Sports Bar-Emmaus",
+   "address": "501 Broad Street, Emmaus, PA",
+   "lat": 40.5325994,
+   "lng": -75.4922906,
+   "types": [
+    "bar"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/473385305"
+  },
+  {
+   "id": "node/2074841888",
+   "name": "Voracious Deli & Catering",
+   "address": "77 West Broad Street, Bethlehem, PA",
+   "lat": 40.6218321,
+   "lng": -75.380717,
+   "types": [
+    "restaurant",
+    "sandwich",
+    "takeaway",
+    "delivery",
+    "outdoor_seating"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 866 2912",
+   "website": "https://voraciousdeliandcatering.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/2074841888"
+  },
+  {
+   "id": "node/13759027734",
+   "name": "Wafa's Kitchen",
+   "address": "515 Hamilton Street, Allentown, PA",
+   "lat": 40.6032013,
+   "lng": -75.4687471,
+   "types": [
+    "restaurant",
+    "middle_eastern"
+   ],
+   "cuisine": [
+    "middle_eastern"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13759027734"
+  },
+  {
+   "id": "way/345724934",
+   "name": "Waffle House",
+   "address": "2101 Cherry Lane",
+   "lat": 40.5938781,
+   "lng": -75.3393746,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-838-2592",
+   "website": "https://locations.wafflehouse.com/bethlehem-pa-1691/",
+   "openingHours": "24/7",
+   "brand": "Waffle House",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/345724934"
+  },
+  {
+   "id": "way/965455986",
+   "name": "Waffle House",
+   "address": "1783 Airport Road, Allentown, PA",
+   "lat": 40.6365076,
+   "lng": -75.4352564,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16102666300",
+   "website": "https://locations.wafflehouse.com/allentown-pa-1594",
+   "openingHours": "24/7",
+   "brand": "Waffle House",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/965455986"
+  },
+  {
+   "id": "node/13127916357",
+   "name": "Wayback Burgers",
+   "address": "5585 Hamilton Boulevard, Allentown, PA",
+   "lat": 40.5616649,
+   "lng": -75.565682,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Wayback Burgers",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13127916357"
+  },
+  {
+   "id": "node/6909493850",
+   "name": "Wendy's",
+   "address": "757 Union Boulevard, Allentown, PA",
+   "lat": 40.6243043,
+   "lng": -75.4455169,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-434-5060",
+   "website": "https://locations.wendys.com/united-states/pa/allentown/757-union-blvd",
+   "openingHours": "07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6909493850"
+  },
+  {
+   "id": "way/30385788",
+   "name": "Wendy's",
+   "address": "308 Broadway, Bethlehem, PA",
+   "lat": 40.6099768,
+   "lng": -75.3827702,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-691-7730",
+   "website": "https://locations.wendys.com/united-states/pa/bethlehem/308-broadway-street",
+   "openingHours": "07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/30385788"
+  },
+  {
+   "id": "way/40294510",
+   "name": "Wendy's",
+   "address": "1160 Hellertown Road, Bethlehem, PA",
+   "lat": 40.5975331,
+   "lng": -75.3409472,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-317-8155",
+   "website": "https://locations.wendys.com/united-states/pa/bethlehem/1160-hellertown-road",
+   "openingHours": "07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/40294510"
+  },
+  {
+   "id": "way/79290969",
+   "name": "Wendy's",
+   "address": "2545 Mickley Avenue, Whitehall, PA",
+   "lat": 40.6446526,
+   "lng": -75.4918143,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-820-5270",
+   "website": "https://locations.wendys.com/united-states/pa/whitehall/2545-mickley-ave",
+   "openingHours": "Mo 10:00-01:00, Tu-Su 10:00-02:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/79290969"
+  },
+  {
+   "id": "way/198872818",
+   "name": "Wendy's",
+   "address": "2190 Stefko Boulevard, Bethlehem, PA",
+   "lat": 40.6441337,
+   "lng": -75.3449257,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-974-9611",
+   "website": "https://locations.wendys.com/united-states/pa/bethlehem/2190-stefko-boulevard",
+   "openingHours": "07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/198872818"
+  },
+  {
+   "id": "way/223606274",
+   "name": "Wendy's",
+   "address": "4688 Broadway, Allentown, PA",
+   "lat": 40.5887136,
+   "lng": -75.5607408,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-391-1204",
+   "website": "https://locations.wendys.com/united-states/pa/allentown/4688-broadway-street",
+   "openingHours": "07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/223606274"
+  },
+  {
+   "id": "way/266642852",
+   "name": "Wendy's",
+   "address": "7142 Hamilton Boulevard, Trexlertown, PA",
+   "lat": 40.5505329,
+   "lng": -75.5960713,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-366-8626",
+   "website": "https://locations.wendys.com/united-states/pa/trexlertown/7142-hamilton-blvd",
+   "openingHours": "06:30-24:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266642852"
+  },
+  {
+   "id": "way/504487532",
+   "name": "Wendy's",
+   "address": "1980 South 4th Street, Allentown, PA",
+   "lat": 40.5778923,
+   "lng": -75.4547559,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-797-4930",
+   "website": "https://locations.wendys.com/united-states/pa/allentown/1980-s-4th-st",
+   "openingHours": "07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/504487532"
+  },
+  {
+   "id": "way/1033696051",
+   "name": "Wendy's",
+   "address": "4896 PA-873, Schnecksville, PA",
+   "lat": 40.6745096,
+   "lng": -75.6126139,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway",
+    "drive_through"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-735-2050",
+   "website": "https://locations.wendys.com/united-states/pa/schnecksville/4896-pa-873",
+   "openingHours": "10:00-01:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1033696051"
+  },
+  {
+   "id": "way/1102510485",
+   "name": "Wendy's",
+   "address": "450 South Cedar Crest Boulevard, Allentown, PA",
+   "lat": 40.5814274,
+   "lng": -75.5227235,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610-432-3369",
+   "website": "https://locations.wendys.com/united-states/pa/allentown/450-s-cedar-crest-blvd",
+   "openingHours": "Mo 07:00-22:00; Tu-Fr 07:00-20:00; Sa-Su 07:00-22:00",
+   "brand": "Wendy's",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1102510485"
+  },
+  {
+   "id": "node/12601535335",
+   "name": "Westside Grill",
+   "address": "",
+   "lat": 40.5633124,
+   "lng": -75.5816592,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12601535335"
+  },
+  {
+   "id": "way/531151867",
+   "name": "White Castle",
+   "address": "1280 MacArthur Road, Whitehall, PA",
+   "lat": 40.6238498,
+   "lng": -75.4824584,
+   "types": [
+    "fast_food",
+    "burger",
+    "takeaway"
+   ],
+   "cuisine": [
+    "burger"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+16104331417",
+   "website": "https://www.whitecastle.com/locations/1303",
+   "openingHours": null,
+   "brand": "White Castle",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531151867"
+  },
+  {
+   "id": "node/11873111388",
+   "name": "White Orchids",
+   "address": "",
+   "lat": 40.460521,
+   "lng": -75.3720829,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11873111388"
+  },
+  {
+   "id": "node/5678995623",
+   "name": "White Orchids Thai Cuisine",
+   "address": "",
+   "lat": 40.5596075,
+   "lng": -75.4126521,
+   "types": [
+    "restaurant",
+    "thai"
+   ],
+   "cuisine": [
+    "thai"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/5678995623"
+  },
+  {
+   "id": "way/531129128",
+   "name": "Whitehall Diner",
+   "address": "3026 MacArthur Road, Whitehall, PA",
+   "lat": 40.6514238,
+   "lng": -75.5020883,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-821-6880",
+   "website": "https://whitehalldiner.com/",
+   "openingHours": "We-Sa 07:00-21:00; Su 07:00-20:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/531129128"
+  },
+  {
+   "id": "way/855934628",
+   "name": "WI FI Cafe & Lounge",
+   "address": "422 Chestnut Street, Emmaus, PA",
+   "lat": 40.5346355,
+   "lng": -75.4924402,
+   "types": [
+    "cafe"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/855934628"
+  },
+  {
+   "id": "way/1318506139",
+   "name": "Wild Turkey Grille",
+   "address": "",
+   "lat": 40.6483453,
+   "lng": -75.5627269,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1318506139"
+  },
+  {
+   "id": "node/6338848531",
+   "name": "Williams Spanish Restaurant",
+   "address": "838 Linden Street, Bethlehem, PA",
+   "lat": 40.6259464,
+   "lng": -75.3702516,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6338848531"
+  },
+  {
+   "id": "way/1347511526",
+   "name": "Willow Street Pub",
+   "address": "2775 Willow Street, Coplay, PA",
+   "lat": 40.6532622,
+   "lng": -75.545339,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+16107993225",
+   "website": "https://willowstreetpub.com/",
+   "openingHours": "11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/1347511526"
+  },
+  {
+   "id": "node/11820457521",
+   "name": "Wingstop",
+   "address": "3926 Nazareth Pike, Bethlehem, PA",
+   "lat": 40.674802,
+   "lng": -75.3421561,
+   "types": [
+    "fast_food",
+    "wings",
+    "takeaway"
+   ],
+   "cuisine": [
+    "wings"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 484-510-8411",
+   "website": null,
+   "openingHours": null,
+   "brand": "Wingstop",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11820457521"
+  },
+  {
+   "id": "node/12597714608",
+   "name": "Wingstop",
+   "address": "1824 Airport Road, Allentown, PA",
+   "lat": 40.6379342,
+   "lng": -75.4360394,
+   "types": [
+    "fast_food",
+    "wings",
+    "takeaway"
+   ],
+   "cuisine": [
+    "wings"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Wingstop",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12597714608"
+  },
+  {
+   "id": "node/13025843980",
+   "name": "Wingstop",
+   "address": "614 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6120815,
+   "lng": -75.3696049,
+   "types": [
+    "fast_food",
+    "wings",
+    "takeaway"
+   ],
+   "cuisine": [
+    "wings"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": "Wingstop",
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13025843980"
+  },
+  {
+   "id": "node/6943100182",
+   "name": "Winston's",
+   "address": "619 North 7th Street, Allentown, PA",
+   "lat": 40.6111052,
+   "lng": -75.4757301,
+   "types": [
+    "restaurant",
+    "jamaican"
+   ],
+   "cuisine": [
+    "jamaican"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6943100182"
+  },
+  {
+   "id": "node/6197048556",
+   "name": "Wishful Thinking Brewing Company",
+   "address": "702 Broadway, Bethlehem, PA",
+   "lat": 40.6064345,
+   "lng": -75.3880844,
+   "types": [
+    "pub"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6197048556"
+  },
+  {
+   "id": "node/13017520742",
+   "name": "Wiz Kids",
+   "address": "751 Union Boulevard, Allentown, PA",
+   "lat": 40.62425,
+   "lng": -75.4458114,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13017520742"
+  },
+  {
+   "id": "node/6342210664",
+   "name": "Wiz Kidz",
+   "address": "65 East Elizabeth Avenue, Bethlehem, PA",
+   "lat": 40.6309858,
+   "lng": -75.3755399,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6342210664"
+  },
+  {
+   "id": "node/12682720751",
+   "name": "Wondaffle",
+   "address": "307 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6122022,
+   "lng": -75.3744377,
+   "types": [
+    "ice_cream"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12682720751"
+  },
+  {
+   "id": "node/12686369248",
+   "name": "Wonder Kitchen",
+   "address": "102 East 4th Street, Bethlehem, PA",
+   "lat": 40.6103621,
+   "lng": -75.3769973,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/12686369248"
+  },
+  {
+   "id": "node/6925915958",
+   "name": "Wun Wu",
+   "address": "225-227 Hamilton Street, Allentown, PA",
+   "lat": 40.6057369,
+   "lng": -75.4610411,
+   "types": [
+    "restaurant",
+    "chinese"
+   ],
+   "cuisine": [
+    "chinese"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/6925915958"
+  },
+  {
+   "id": "way/653274808",
+   "name": "Ye Olde Spring Valley Tavern",
+   "address": "1355 Station Avenue, Bethlehem, PA",
+   "lat": 40.5517192,
+   "lng": -75.3588711,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+14848513594",
+   "website": "https://oldespringvt.com/",
+   "openingHours": "We,Th 16:00-21:00; Fr 16:00-22:00; Sa 12:00-22:00; Su 12:00-19:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/653274808"
+  },
+  {
+   "id": "way/383922358",
+   "name": "Yianni's Taverna",
+   "address": "3760 Old Philadelphia Pike, Bethlehem, PA",
+   "lat": 40.5909991,
+   "lng": -75.3887903,
+   "types": [
+    "restaurant",
+    "greek"
+   ],
+   "cuisine": [
+    "greek"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 867-8821",
+   "website": "https://www.yiannistaverna.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/383922358"
+  },
+  {
+   "id": "node/3370231036",
+   "name": "Yocco's",
+   "address": "225 PA 100, Allentown",
+   "lat": 40.5759095,
+   "lng": -75.6205489,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://yoccos.com",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/3370231036"
+  },
+  {
+   "id": "node/9919736804",
+   "name": "Yocco's",
+   "address": "1930 Catasauqua Road, Allentown, PA",
+   "lat": 40.6413182,
+   "lng": -75.4287675,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/9919736804"
+  },
+  {
+   "id": "node/7935299271",
+   "name": "Yocco's Hot Dogs",
+   "address": "3300 Lehigh Street, Allentown, PA",
+   "lat": 40.5552194,
+   "lng": -75.4917257,
+   "types": [
+    "fast_food"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": "https://www.yoccos.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/7935299271"
+  },
+  {
+   "id": "way/266641243",
+   "name": "Yocco's Hot Dogs",
+   "address": "2128 Hamilton Street, Allentown",
+   "lat": 40.5937189,
+   "lng": -75.5017423,
+   "types": [
+    "fast_food",
+    "hot_dog"
+   ],
+   "cuisine": [
+    "hot_dog"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610 821 8488",
+   "website": "http://www.yoccos.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266641243"
+  },
+  {
+   "id": "way/266642090",
+   "name": "Yocco's Hot Dogs",
+   "address": "7150 Hamilton Boulevard, Trexlertown",
+   "lat": 40.5501687,
+   "lng": -75.5971766,
+   "types": [
+    "fast_food",
+    "regional"
+   ],
+   "cuisine": [
+    "regional"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": "+1 610 530 4480",
+   "website": "http://www.yoccos.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/266642090"
+  },
+  {
+   "id": "way/278756643",
+   "name": "Yocco's Hot Dogs",
+   "address": "4042 Chestnut Street, Emmaus, PA",
+   "lat": 40.519831,
+   "lng": -75.5212369,
+   "types": [
+    "restaurant",
+    "american"
+   ],
+   "cuisine": [
+    "american"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 967 5555",
+   "website": "http://www.yoccos.com/",
+   "openingHours": "Tu 11:00-20:00; We-Su 11:00-21:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/278756643"
+  },
+  {
+   "id": "node/11905435301",
+   "name": "YoFresh",
+   "address": "4642 Broadway, Allentown, PA",
+   "lat": 40.58741,
+   "lng": -75.5613531,
+   "types": [
+    "ice_cream",
+    "frozen_yogurt"
+   ],
+   "cuisine": [
+    "frozen_yogurt"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11905435301"
+  },
+  {
+   "id": "way/864764229",
+   "name": "Youell's Oyster House",
+   "address": "2249 West Walnut Street, Allentown",
+   "lat": 40.5919106,
+   "lng": -75.5040368,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610-439-1203",
+   "website": "https://youellsoysterhouse.com/",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/way/864764229"
+  },
+  {
+   "id": "node/11906449357",
+   "name": "Yummy Bowl Mongolian Stir Fry",
+   "address": "2544 MacArthur Road, Whitehall, PA",
+   "lat": 40.6437876,
+   "lng": -75.4947226,
+   "types": [
+    "restaurant",
+    "asian"
+   ],
+   "cuisine": [
+    "asian"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://yummybowl.us/",
+   "openingHours": "Mo-Th,Su 11:00-21:00; Fr-Sa 11:00-22:00",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/11906449357"
+  },
+  {
+   "id": "node/13061217829",
+   "name": "Zandy's Steak Shop",
+   "address": "813 Saint John Street, Allentown, PA",
+   "lat": 40.591507,
+   "lng": -75.4697158,
+   "types": [
+    "fast_food",
+    "sandwich"
+   ],
+   "cuisine": [
+    "sandwich"
+   ],
+   "dietary": [],
+   "priceLevel": 1,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13061217829"
+  },
+  {
+   "id": "node/10543203153",
+   "name": "Zest Bar & Grille",
+   "address": "306 South New Street, Bethlehem, PA",
+   "lat": 40.6117837,
+   "lng": -75.3787249,
+   "types": [
+    "restaurant",
+    "outdoor_seating"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": "+1 610 419 4320",
+   "website": "https://www.zestbethlehem.com/",
+   "openingHours": "Tu-Th 16:00-21:30; Fr-Sa 16:00-22:00; Su 10:30-14:30",
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/10543203153"
+  },
+  {
+   "id": "node/13204545506",
+   "name": "Zime",
+   "address": "511 East 3rd Street, Bethlehem, PA",
+   "lat": 40.6123746,
+   "lng": -75.3715244,
+   "types": [
+    "restaurant"
+   ],
+   "cuisine": [],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": "https://northampton.sodexomyway.com/en-us/locations/fowler-zime",
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/13204545506"
+  },
+  {
+   "id": "node/4326260599",
+   "name": "Zio's Pizzeria",
+   "address": "4660 Broadway, Allentown, PA",
+   "lat": 40.5879421,
+   "lng": -75.5611616,
+   "types": [
+    "restaurant",
+    "pizza"
+   ],
+   "cuisine": [
+    "pizza"
+   ],
+   "dietary": [],
+   "priceLevel": null,
+   "phone": null,
+   "website": null,
+   "openingHours": null,
+   "brand": null,
+   "wheelchair": null,
+   "osmUrl": "https://www.openstreetmap.org/node/4326260599"
+  }
+ ]
 }

--- a/backend/scripts/build-places.mjs
+++ b/backend/scripts/build-places.mjs
@@ -12,6 +12,18 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const [latArg, lngArg, radiusArg] = process.argv.slice(2);
+
+// Arguments are positional, so a stray flag like --help used to land in latArg,
+// become NaN, and quietly produce an empty dataset that looked like a
+// successful build. Refuse to run rather than write nonsense.
+for (const [name, value] of [["latitude", latArg], ["longitude", lngArg], ["radius", radiusArg]]) {
+  if (value !== undefined && !Number.isFinite(Number(value))) {
+    console.error(`Bad ${name}: ${JSON.stringify(value)}\n` +
+      `Usage: node scripts/build-places.mjs [lat] [lng] [radiusMeters]`);
+    process.exit(1);
+  }
+}
+
 const LAT = Number(latArg ?? 40.6084);
 const LNG = Number(lngArg ?? -75.4902);
 const RADIUS = Number(radiusArg ?? 20000);
@@ -145,6 +157,14 @@ for (const el of elements) {
 places.sort((a, b) => a.name.localeCompare(b.name));
 
 await mkdir(dirname(OUT), { recursive: true });
+if (places.length === 0) {
+  console.error(
+    "Overpass returned no places. Refusing to overwrite data/places.json —\n" +
+    "the previous dataset is still in place. Check the coordinates and retry."
+  );
+  process.exit(1);
+}
+
 await writeFile(
   OUT,
   JSON.stringify(


### PR DESCRIPTION
Two things: main is currently serving an empty dataset, and the app only ever worked for one region.

## 1. Restore the dataset (the reason this is urgent)

`backend/data/places.json` is **empty on main** — `count: 0`, `places: []` — so the deployed backend returns no restaurants.

**Cause, and it was mine.** I ran `node backend/scripts/build-places.mjs --help` expecting a no-op. Arguments are positional, so `--help` became the latitude, `Number("--help")` was `NaN`, Overpass matched nothing, and `git commit -am` swept the empty output into `ce5ca92`.

- Regenerated: **1,032 places**, centre `40.6084, -75.4902`.
- Non-numeric args now exit with usage instead of coercing to `NaN`.
- The build refuses to overwrite `places.json` when a query returns zero places.

## 2. Search from any US ZIP

- `data/zips.json` — 33,791 Census ZCTA centroids (public domain), so a ZIP resolves locally with **no geocoding service in the request path**.
- `osm.js` — the Overpass query and normaliser, now shared by the build script and the server, so a live-fetched place is shaped exactly like a baked one.
- `areas.js` — fetches an unknown area once, then serves it from memory and disk. **Manhattan cold 13.4s, cached 0.05s**; survives restarts.
- The home region is unchanged: still served from memory, no network.
- Details and photo routes also look in fetched areas, so a ZIP-search result opens correctly.
- Frontend: a ZIP box beside the search bar.

Verified: 10001 → 18,245 places · 60601 → 6,329 · 02139 → 4,207 · 59730 (rural MT) → 21 · invalid ZIP → 400.

## A bug this shook out

Overpass signals overload as **HTTP 200 with a `remark` and no elements**, which is indistinguishable from "no restaurants here". That was being cached for seven days — 90210 came back empty and would have stayed empty. Now an empty or remark-bearing response fails over to the next mirror, empty results expire in 30 minutes rather than 7 days, and total failure returns **503** instead of a confident empty list.

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_