### PR TITLE
Cap the Overpass query itself — #18 trimmed too late

### DIFF
--- a/backend/areas.js
+++ b/backend/areas.js
@@ -129,6 +129,9 @@ export async function areaFor({ lat, lng, radius = DEFAULT_RADIUS }, baked) {
     }
     let places;
     try {
+      // One request, capped at the source. Asking twice — tight radius then
+      // wide — reads better but gets the second query rate-limited by every
+      // Overpass mirror, which broke rural searches entirely.
       places = trimToRadius(normalise(await fetchElements(lat, lng, radius)), lat, lng);
     } catch (err) {
       // Don't poison the cache with a failure — let the caller say so.

--- a/backend/osm.js
+++ b/backend/osm.js
@@ -13,17 +13,22 @@ const ENDPOINTS = [
 
 const AMENITIES = "restaurant|cafe|fast_food|bar|pub|ice_cream";
 
-export function overpassQuery(lat, lng, radius) {
+// `out` takes a cap. Without it a dense city returns tens of thousands of
+// elements, and simply receiving and parsing that is what exhausts memory —
+// trimming afterwards is far too late.
+export const ELEMENT_CAP = 2500;
+
+export function overpassQuery(lat, lng, radius, cap = ELEMENT_CAP) {
   return `
 [out:json][timeout:60];
 (
   node["amenity"~"^(${AMENITIES})$"](around:${radius},${lat},${lng});
   way ["amenity"~"^(${AMENITIES})$"](around:${radius},${lat},${lng});
 );
-out center tags;`;
+out center tags ${cap};`;
 }
 
-export async function fetchElements(lat, lng, radius, { log = () => {} } = {}) {
+export async function fetchElements(lat, lng, radius, { log = () => {}, cap = ELEMENT_CAP } = {}) {
   let lastError;
   for (const url of ENDPOINTS) {
     try {
@@ -34,7 +39,7 @@ export async function fetchElements(lat, lng, radius, { log = () => {} } = {}) {
           "content-type": "application/x-www-form-urlencoded",
           "user-agent": "dinevalley/1.0 (portfolio project)",
         },
-        body: new URLSearchParams({ data: overpassQuery(lat, lng, radius) }),
+        body: new URLSearchParams({ data: overpassQuery(lat, lng, radius, cap) }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();


### PR DESCRIPTION
## Why #18 didn't hold

PR #18 capped each area at 1,500 places, but the trim ran **after** `fetchElements` and `normalise`. Manhattan still meant downloading ~5.7 MB, parsing 18,245 objects and normalising all of them before throwing most away — the memory peak that kills the process happens before the trim runs.

Production confirmed it: after #18 merged, `zip=10001` still returned an empty body and took the next unrelated request down with it.

## The fix

Overpass's `out` statement accepts a limit, so the cap applies at the source and the elements are never received at all.

Verified locally, cold cache:

| ZIP | | result |
| --- | --- | --- |
| 10001 | Manhattan | 1,500 · **117 MB peak, no crash** |
| 90210 | Beverly Hills | 1,500 |
| 18015 | Bethlehem | 1,301 |
| 59730 | Big Sky | 21 |
| — | home region afterwards | still serving |

## Trade-off, stated plainly

In a very dense area the capped set is Overpass's own ordering rather than the nearest 2,500. Results are still distance-sorted before paging, so the effect is a slightly shallower tail in dense cities — not wrong results, just fewer far ones.

I also tried a tight-radius-first strategy that widens only when results are thin. It reads better, but it fires two requests and the second gets rate-limited by every Overpass mirror, which broke rural searches entirely. Reverted.