### PR TITLE
Answer a question instead of listing a thousand places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Unit tests
+        run: npm test
+
       - name: Smoke test server start
-        env:
-          GOOGLE_PLACES_API_KEY: dummy-key
         run: |
           node server.js &
           SERVER_PID=$!

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ frontend/package-lock.json
 
 # runtime area cache — rebuilt on demand
 backend/data/cache/
+
+# Claude Code local config
+.claude/

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "data:build": "node scripts/build-places.mjs"
   },
   "keywords": [],

--- a/backend/places.js
+++ b/backend/places.js
@@ -34,7 +34,7 @@ const searchText = (p) =>
   [p.name, p.brand, p.address, ...p.types, ...p.cuisine, ...p.dietary]
     .filter(Boolean).join(" ").toLowerCase();
 
-function distanceMeters(a, b) {
+export function distanceMeters(a, b) {
   const R = 6371000, toRad = (d) => (d * Math.PI) / 180;
   const dLat = toRad(b.lat - a.lat), dLng = toRad(b.lng - a.lng);
   const s =

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ import {
   toCard, toDetails, placeholderSvg,
 } from "./places.js";
 import { areaFor, centerForZip, loadZips, findCached } from "./areas.js";
+import { decide, TRAVEL_SPEEDS } from "./solver.js";
 import { imageForPlace, loadImageCache, imageCacheStats } from "./preview.js";
 
 dotenv.config();
@@ -184,6 +185,76 @@ app.get("/restaurants", async (req, res) => {
   } catch (error) {
     console.error("❌ Search failed:", error.message);
     res.status(500).json({ error: "Failed to fetch restaurants", details: error.message });
+  }
+});
+
+
+/* The decision endpoint.
+ *
+ * `/restaurants` answers "what is near here", which is the question Google
+ * Maps already answers better. This answers "given these constraints, where
+ * should we go" — and returns the short list with its reasoning attached,
+ * rather than a thousand rows and a star rating we do not have. */
+app.get("/decide", async (req, res) => {
+  try {
+    const {
+      zip, lat, lng, minutes, mode, kinds, cuisines,
+      independent, openNow, maxPrice, dietary, limit,
+    } = req.query;
+
+    let center = null;
+    if (zip) {
+      center = centerForZip(zip);
+      if (!center) {
+        return res.status(400).json({
+          error: /^\d{5}$/.test(String(zip))
+            ? `We don't have a location for ZIP ${zip}. Try a nearby one.`
+            : `"${String(zip).slice(0, 12)}" isn't a five-digit ZIP code.`,
+        });
+      }
+    } else if (Number.isFinite(Number(lat)) && Number.isFinite(Number(lng))) {
+      center = { lat: Number(lat), lng: Number(lng) };
+    } else {
+      center = meta().center;          // the valley itself, so the page is never empty
+    }
+
+    const list = (v) => String(v || "").split(",").map((x) => x.trim()).filter(Boolean);
+    const travelMode = mode === "walk" ? "walk" : "drive";
+    const maxMinutes = Math.min(60, Math.max(1, Number(minutes) || 15));
+
+    const { results, considered, matchedTag } = decide({
+      places: meta().dataset.places,
+      center,
+      maxMinutes,
+      mode: travelMode,
+      kinds: list(kinds),
+      cuisines: list(cuisines),
+      independentOnly: independent === "true",
+      openNow: openNow === "true",
+      maxPrice: Number.isFinite(Number(maxPrice)) ? Number(maxPrice) : null,
+      dietary: list(dietary),
+      limit: Math.min(20, Math.max(1, Number(limit) || 8)),
+    });
+
+    const baseUrl = `${req.protocol}://${req.get("host")}`;
+    res.json({
+      results: results.map((r) => ({
+        ...toCard(r.place, baseUrl),
+        minutes: r.minutes,
+        metres: Math.round(r.metres),
+        matchScore: r.score,
+        reasons: r.reasons,
+        independent: !r.place.brand,
+      })),
+      considered,
+      matchedTag,
+      center,
+      budget: { minutes: maxMinutes, mode: travelMode, metres: maxMinutes * TRAVEL_SPEEDS[travelMode] },
+      attribution: meta().attribution,
+    });
+  } catch (error) {
+    console.error("❌ Decide failed:", error.message);
+    res.status(500).json({ error: "Failed to work out a shortlist", details: error.message });
   }
 });
 

--- a/backend/solver.js
+++ b/backend/solver.js
@@ -1,0 +1,231 @@
+// The decision engine — narrow a thousand places to a handful, and say why.
+//
+// This is the part that is not a worse Google Maps. Maps is better than us at
+// "restaurants near me" and always will be. What it cannot do is take four
+// people's constraints at once and return the short list that satisfies them,
+// which is the question anyone actually has at 6pm on a Tuesday.
+//
+// The honest shape of that is set by how complete the data is, so it is worth
+// writing the coverage down. Out of 1,032 places in the baked dataset:
+//
+//   lat/lng, types      100%     safe to filter on
+//   address              85%
+//   cuisine              66%     safe to filter on
+//   brand (=> chain)     28%     absence means independent, 72% of the file
+//   priceLevel           29%     too sparse to exclude on
+//   openingHours         25%     too sparse to exclude on
+//   takeaway             23%
+//   dietary               1%     nine vegan places in the whole valley
+//   wheelchair            0%     three records, total
+//
+// So the rule this module is built on: **sparse attributes rank, they never
+// exclude.** Filtering on `dietary` would return an empty page and call it an
+// answer. Instead a requested-but-unknown attribute keeps the place in the
+// list, costs it some score, and is reported as unknown on the card — the
+// visitor can see that we do not know rather than being told there is nothing.
+//
+// The one exception is a *known* negative. If OSM says a place is closed right
+// now, and the visitor asked for open places, that is real information and the
+// place is dropped. Unknown is not the same as no, and neither is the same as
+// yes.
+
+import { distanceMeters, isOpenNow } from "./places.js";
+
+// Metres per minute. Walking is the standard 4.8 km/h; driving is deliberately
+// a town speed rather than a highway one, because a 15-minute drive that
+// assumes 60 km/h will put a result three towns away.
+export const TRAVEL_SPEEDS = { walk: 80, drive: 600 };
+
+// What each signal is worth. They sum to 1 so the score reads as a percentage,
+// and every one of them turns into a line the card can show — a score nobody
+// can decompose is the thing this project already refuses to ship elsewhere.
+export const WEIGHTS = {
+  proximity: 0.40,   // the constraint people actually feel
+  open: 0.25,
+  price: 0.15,
+  described: 0.20,   // a fully tagged place is a better recommendation than a bare name
+};
+
+const KIND_TAGS = {
+  restaurant: ["restaurant"],
+  fast_food: ["fast_food"],
+  cafe: ["cafe", "coffee_shop"],
+  bar: ["bar", "pub"],
+  dessert: ["ice_cream", "donut", "bakery"],
+};
+
+const has = (place, tag) => (place.types || []).includes(tag);
+
+const matchesKind = (place, kinds) =>
+  !kinds?.length || kinds.some((k) => (KIND_TAGS[k] || [k]).some((t) => has(place, t)));
+
+const matchesCuisine = (place, cuisines) =>
+  !cuisines?.length ||
+  cuisines.some((c) => (place.cuisine || []).includes(c) || has(place, c));
+
+/* How completely a place is described. A recommendation you cannot act on --
+   no address, no hours, no cuisine -- is worse than one you can, even if it is
+   marginally closer. Normalised to 0..1 so it can carry a weight. */
+const describedness = (place) => {
+  const points =
+    (place.address ? 2 : 0) +
+    (place.cuisine?.length ? 2 : 0) +
+    (place.openingHours ? 2 : 0) +
+    (place.website ? 1 : 0) +
+    (place.phone ? 1 : 0);
+  return points / 8;
+};
+
+/**
+ * Narrow the dataset to the places that satisfy every hard constraint, then
+ * rank what survives and explain each result.
+ *
+ * Hard constraints (a place is dropped): travel budget, venue kind, cuisine,
+ * independent-only, and a *known* conflict on open-now or price.
+ * Soft signals (a place is ranked): proximity, open, price, describedness,
+ * plus any requested dietary tag.
+ */
+export function decide({
+  places,
+  center,
+  maxMinutes = 15,
+  mode = "drive",
+  kinds = [],
+  cuisines = [],
+  independentOnly = false,
+  openNow = false,
+  maxPrice = null,
+  dietary = [],
+  limit = 8,
+  now = new Date(),
+} = {}) {
+  const speed = TRAVEL_SPEEDS[mode] ?? TRAVEL_SPEEDS.drive;
+  const budgetMeters = maxMinutes * speed;
+
+  const scored = [];
+
+  for (const place of places) {
+    const metres = distanceMeters(center, place);
+    if (metres > budgetMeters) continue;
+    if (!matchesKind(place, kinds)) continue;
+    if (!matchesCuisine(place, cuisines)) continue;
+    if (independentOnly && place.brand) continue;
+
+    const open = isOpenNow(place, now);          // true | false | null(unknown)
+    if (openNow && open === false) continue;     // a known negative is real information
+
+    const priceKnown = place.priceLevel !== null && place.priceLevel !== undefined;
+    if (maxPrice !== null && priceKnown && place.priceLevel > maxPrice) continue;
+
+    const reasons = [];
+
+    // -- proximity ---------------------------------------------------------
+    const minutes = Math.max(1, Math.round(metres / speed));
+    const proximity = 1 - metres / budgetMeters;
+    reasons.push({
+      kind: "match",
+      label: `${minutes} min ${mode === "walk" ? "walk" : "drive"}`,
+      weight: WEIGHTS.proximity,
+    });
+
+    // -- open now ----------------------------------------------------------
+    let openScore;
+    if (open === true) {
+      openScore = 1;
+      reasons.push({ kind: "match", label: "open now", weight: WEIGHTS.open });
+    } else if (open === null) {
+      // Half credit, and said out loud. Silently scoring it zero would bury
+      // three quarters of the valley for having no hours on OSM.
+      openScore = 0.5;
+      reasons.push({ kind: "unknown", label: "hours unknown", weight: WEIGHTS.open });
+    } else {
+      openScore = 0;
+      reasons.push({ kind: "miss", label: "closed now", weight: WEIGHTS.open });
+    }
+
+    // -- price -------------------------------------------------------------
+    let priceScore;
+    if (priceKnown) {
+      priceScore = place.priceLevel <= 1 ? 1 : 0.6;
+      reasons.push({
+        kind: "match",
+        label: "$".repeat(Math.max(1, place.priceLevel)),
+        weight: WEIGHTS.price,
+      });
+    } else {
+      priceScore = 0.5;
+      if (maxPrice !== null) {
+        reasons.push({ kind: "unknown", label: "price unknown", weight: WEIGHTS.price });
+      }
+    }
+
+    // -- dietary: a bonus, never a filter ----------------------------------
+    // Nine vegan records in the whole file. Excluding on this would return an
+    // empty page; ranking on it surfaces those nine first and admits the rest
+    // are simply untagged.
+    let dietaryBonus = 0;
+    let dietaryMatched = false;
+    for (const want of dietary) {
+      if ((place.dietary || []).includes(want)) {
+        dietaryMatched = true;
+        dietaryBonus += 0.15;
+        reasons.push({ kind: "bonus", label: `${want.replace("_", " ")} options`, weight: 0.15 });
+      } else {
+        reasons.push({ kind: "unknown", label: `${want.replace("_", " ")} not listed`, weight: 0 });
+      }
+    }
+
+    if (independentOnly || !place.brand) {
+      reasons.push({
+        kind: place.brand ? "miss" : "bonus",
+        label: place.brand ? `${place.brand} chain` : "independent",
+        weight: 0,
+      });
+    }
+
+    const described = describedness(place);
+    const base =
+      WEIGHTS.proximity * proximity +
+      WEIGHTS.open * openScore +
+      WEIGHTS.price * priceScore +
+      WEIGHTS.described * described;
+
+    scored.push({
+      place,
+      metres,
+      minutes,
+      dietaryMatched,
+      score: Math.round(100 * Math.min(1, base + dietaryBonus)),
+      reasons,
+    });
+  }
+
+  /* Ask for vegan and the first build of this returned McDonald's at rank two,
+     on the strength of being close and well described. A 15% bonus cannot
+     outweigh proximity, and "vegan not listed" sitting second is exactly the
+     confidently-useless answer this rewrite exists to stop.
+
+     So a requested tag is a tier, not a nudge. Everything that actually
+     carries the tag sorts above everything that does not, and the untagged
+     remainder still follows — labelled — because nine tagged places in the
+     valley is not a long enough list to be someone's only answer. */
+  const tier = (r) => (dietary.length && r.dietaryMatched ? 1 : 0);
+  scored.sort((a, b) => tier(b) - tier(a) || b.score - a.score || a.metres - b.metres);
+
+  /* One entry per chain. Three Chipotles in a four-item shortlist is three
+     wasted slots — the visitor has already decided about Chipotle. Independent
+     places have no brand and are never collapsed. */
+  const seenBrand = new Set();
+  const results = [];
+  for (const r of scored) {
+    const brand = r.place.brand;
+    if (brand) {
+      if (seenBrand.has(brand)) continue;
+      seenBrand.add(brand);
+    }
+    results.push(r);
+    if (results.length >= limit) break;
+  }
+
+  return { results, considered: scored.length, matchedTag: scored.filter((r) => r.dietaryMatched).length };
+}

--- a/backend/solver.test.js
+++ b/backend/solver.test.js
@@ -1,0 +1,210 @@
+// The rules the solver must not quietly break.
+//
+// The one that matters most: a sparse attribute may rank a place, but it may
+// never exclude one. Nine places in the dataset carry a `dietary` tag, so a
+// solver that filtered on it would answer "there is nowhere vegan in the
+// Lehigh Valley" — confidently, and wrongly. Several tests below exist only to
+// stop that regressing.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { decide, TRAVEL_SPEEDS, WEIGHTS } from "./solver.js";
+
+const CENTER = { lat: 40.6, lng: -75.49 };
+
+/* Roughly a kilometre north per 0.009 degrees of latitude — near enough for
+   fixtures, and the real haversine still does the measuring. */
+const at = (kmNorth, over = {}) => ({
+  id: `n/${kmNorth}-${over.name ?? ""}`,
+  name: over.name ?? `Place ${kmNorth}km`,
+  lat: CENTER.lat + kmNorth * 0.009,
+  lng: CENTER.lng,
+  address: "1 Main St, Allentown, PA",
+  types: ["restaurant"],
+  cuisine: [],
+  dietary: [],
+  priceLevel: null,
+  phone: null,
+  website: null,
+  openingHours: null,
+  brand: null,
+  ...over,
+});
+
+const run = (places, opts = {}) => decide({ places, center: CENTER, ...opts });
+
+test("the travel budget is a real distance, not a radius guess", () => {
+  const places = [at(1), at(5), at(50)];
+  // 15 minutes of walking is 1.2 km, so only the first place is reachable.
+  const walk = run(places, { mode: "walk", maxMinutes: 15 });
+  assert.equal(walk.results.length, 1);
+  assert.equal(walk.results[0].place.name, "Place 1km");
+
+  // The same 15 minutes by car reaches 9 km.
+  const drive = run(places, { mode: "drive", maxMinutes: 15 });
+  assert.equal(drive.results.length, 2);
+});
+
+test("a requested dietary tag ranks a place but never excludes one", () => {
+  const places = [at(5, { name: "Untagged" }), at(6, { name: "Vegan Spot", dietary: ["vegan"] })];
+  const { results } = run(places, { dietary: ["vegan"], maxMinutes: 30 });
+
+  // Both survive — this is the whole point.
+  assert.equal(results.length, 2, "an untagged place must not be filtered out");
+  // But the tagged one wins despite being further away.
+  assert.equal(results[0].place.name, "Vegan Spot");
+  const untagged = results.find((r) => r.place.name === "Untagged");
+  assert.ok(
+    untagged.reasons.some((r) => r.kind === "unknown" && r.label.includes("vegan")),
+    "an untagged place must say the tag is unknown rather than staying silent"
+  );
+});
+
+test("unknown hours keep a place; a known closure removes it", () => {
+  const unknown = at(2, { name: "No Hours" });
+  const closed = at(2, { name: "Closed", openingHours: "Mo-Su 03:00-04:00" });
+  const open = at(2, { name: "Open", openingHours: "Mo-Su 00:00-24:00" });
+
+  const { results } = run([unknown, closed, open], { openNow: true, maxMinutes: 30 });
+  const names = results.map((r) => r.place.name);
+
+  assert.ok(names.includes("No Hours"), "unknown is not the same as closed");
+  assert.ok(names.includes("Open"));
+  assert.ok(!names.includes("Closed"), "a known closure is real information and should filter");
+});
+
+test("unknown price keeps a place; a known overshoot removes it", () => {
+  const unknown = at(2, { name: "No Price" });
+  const cheap = at(2, { name: "Cheap", priceLevel: 1 });
+  const pricey = at(2, { name: "Pricey", priceLevel: 3 });
+
+  const names = run([unknown, cheap, pricey], { maxPrice: 1, maxMinutes: 30 })
+    .results.map((r) => r.place.name);
+
+  assert.ok(names.includes("No Price"));
+  assert.ok(names.includes("Cheap"));
+  assert.ok(!names.includes("Pricey"));
+});
+
+test("independent-only excludes branded chains", () => {
+  const places = [at(2, { name: "Local" }), at(2, { name: "Chipotle", brand: "Chipotle" })];
+  const names = run(places, { independentOnly: true, maxMinutes: 30 })
+    .results.map((r) => r.place.name);
+  assert.deepEqual(names, ["Local"]);
+});
+
+test("cuisine matches either the cuisine list or the type tags", () => {
+  const viaCuisine = at(2, { name: "By Cuisine", cuisine: ["pizza"] });
+  const viaType = at(2, { name: "By Type", types: ["restaurant", "pizza"] });
+  const neither = at(2, { name: "Neither", cuisine: ["sushi"] });
+
+  const names = run([viaCuisine, viaType, neither], { cuisines: ["pizza"], maxMinutes: 30 })
+    .results.map((r) => r.place.name);
+
+  assert.ok(names.includes("By Cuisine") && names.includes("By Type"));
+  assert.ok(!names.includes("Neither"));
+});
+
+test("kinds group the tags a visitor would not think to distinguish", () => {
+  const cafe = at(2, { name: "Cafe", types: ["cafe"] });
+  const coffee = at(2, { name: "Coffee", types: ["coffee_shop"] });
+  const bar = at(2, { name: "Bar", types: ["pub"] });
+
+  const names = run([cafe, coffee, bar], { kinds: ["cafe"], maxMinutes: 30 })
+    .results.map((r) => r.place.name);
+  assert.deepEqual(names.sort(), ["Cafe", "Coffee"]);
+});
+
+test("every result explains itself, and the weights sum to one", () => {
+  const total = Object.values(WEIGHTS).reduce((a, b) => a + b, 0);
+  assert.ok(Math.abs(total - 1) < 1e-9, `weights sum to ${total}, so the score is not a percentage`);
+
+  const { results } = run([at(2, { name: "Somewhere", cuisine: ["pizza"], priceLevel: 1 })], {
+    maxMinutes: 30,
+  });
+  const [top] = results;
+  assert.ok(top.reasons.length > 0, "a score with no reasons is the thing we are avoiding");
+  assert.ok(top.score >= 0 && top.score <= 100);
+  for (const r of top.reasons) {
+    assert.ok(["match", "bonus", "unknown", "miss"].includes(r.kind));
+    assert.ok(typeof r.label === "string" && r.label.length > 0);
+  }
+});
+
+test("a closer place beats a further one, all else equal", () => {
+  const { results } = run([at(8, { name: "Far" }), at(1, { name: "Near" })], { maxMinutes: 30 });
+  assert.equal(results[0].place.name, "Near");
+});
+
+test("a fully described place outranks a bare name at the same distance", () => {
+  const bare = at(3, { name: "Bare", address: null });
+  const full = at(3, {
+    name: "Full",
+    cuisine: ["italian"],
+    openingHours: "Mo-Su 00:00-24:00",
+    website: "https://example.com",
+    phone: "555",
+  });
+  const { results } = run([bare, full], { maxMinutes: 30 });
+  assert.equal(results[0].place.name, "Full");
+});
+
+test("walking is slower than driving, which is the only reason the mode exists", () => {
+  assert.ok(TRAVEL_SPEEDS.walk < TRAVEL_SPEEDS.drive);
+});
+
+test("the limit caps results without hiding how many matched", () => {
+  const places = Array.from({ length: 30 }, (_, i) => at(1 + i * 0.1, { name: `P${i}` }));
+  const { results, considered } = run(places, { maxMinutes: 30, limit: 5 });
+  assert.equal(results.length, 5);
+  assert.equal(considered, 30, "the visitor should be able to be told what the 5 came out of");
+});
+
+test("a requested tag is a tier, not a nudge — untagged cannot outrank tagged", () => {
+  // The first build returned McDonald's at rank two for a vegan search, on the
+  // strength of being close and well described. Proximity must not be able to
+  // buy its way above an actual match.
+  const chain = at(0.5, {
+    name: "McDonald's", brand: "McDonald's", priceLevel: 1,
+    cuisine: ["burger"], openingHours: "Mo-Su 00:00-24:00",
+    website: "https://mcdonalds.com", phone: "555",
+  });
+  const vegan = at(8, { name: "Vegan Far", dietary: ["vegan"] });
+
+  const { results } = run([chain, vegan], { dietary: ["vegan"], maxMinutes: 30 });
+  assert.equal(results[0].place.name, "Vegan Far", "a tagged match must outrank an untagged one");
+  assert.equal(results.length, 2, "the untagged remainder still follows, labelled");
+});
+
+test("one entry per chain, so a shortlist is not three of the same brand", () => {
+  const places = [
+    at(1, { name: "Chipotle", brand: "Chipotle" }),
+    at(2, { name: "Chipotle", brand: "Chipotle" }),
+    at(3, { name: "Chipotle", brand: "Chipotle" }),
+    at(4, { name: "Local Spot" }),
+  ];
+  const { results } = run(places, { maxMinutes: 30 });
+  const names = results.map((r) => r.place.name);
+  assert.equal(names.filter((n) => n === "Chipotle").length, 1, "a chain gets one slot");
+  assert.ok(names.includes("Local Spot"));
+});
+
+test("independents are never collapsed together", () => {
+  // They share no brand, so two unrelated places must both survive.
+  const places = [at(1, { name: "Ann's" }), at(2, { name: "Bob's" })];
+  const { results } = run(places, { maxMinutes: 30 });
+  assert.equal(results.length, 2);
+});
+
+test("the nearest branch is the one a chain keeps", () => {
+  const places = [
+    at(9, { name: "Chipotle", brand: "Chipotle" }),
+    at(1, { name: "Chipotle", brand: "Chipotle" }),
+  ];
+  const { results } = run(places, { maxMinutes: 30 });
+  assert.equal(results.length, 1);
+  // Assert on the measured distance rather than the rounded minutes, which
+  // depend on the travel speed and would make this a test of arithmetic.
+  assert.ok(results[0].metres < 2000, "the surviving branch should be the closest one");
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { fetchRestaurants, fetchRestaurantDetails } from "./api/restaurants";
 import { useLocalStorage } from "./hooks/useLocalStorage";
 import { AssistantChatWidget } from "./components/AssistantChatWidget";
 import { KNOWN_CUISINES } from "./utils/restaurantFilters";
+import DecidePage from "./sections/MainContent/DecidePage";
 
 const SHUFFLE_KEYWORDS = [
   "restaurant",
@@ -39,11 +40,12 @@ const shuffleArray = <T,>(items: T[]): T[] => {
   }
   return array;
 };
-export type Page = "discover" | "recommendations" | "profile" | "restaurant-details";
+export type Page = "decide" | "discover" | "recommendations" | "profile" | "restaurant-details";
 type Theme = "light" | "dark";
 
 export const App = () => {
-  const [currentPage, setCurrentPage] = useState<Page>("discover");
+  const [currentPage, setCurrentPage] = useState<Page>("decide");
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedRestaurantId, setSelectedRestaurantId] = useState<string | null>(null);
   const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
   const [nextPageToken, setNextPageToken] = useState<string | null>(null);
@@ -140,14 +142,30 @@ export const App = () => {
     [buildVisitSnapshot, setVisitHistory]
   );
 
+  /* This used to catch, console.error, and leave an empty list on screen for
+     good. On Render's free tier the backend sleeps, so the very first request
+     after an idle spell fails — and because this only runs once on mount, the
+     app then sat at "Page 0 of 0" forever with no error and no retry. That is
+     what made it look broken to whoever arrived first. Retry a few times with
+     backoff, and keep the failure where the UI can show it. */
   const loadRestaurants = useCallback(async () => {
-    try {
-      const data = await fetchRestaurants({ keyword: "restaurant" });
-      setRestaurants(data.results);
-      setNextPageToken(data.nextPageToken);
-    } catch (err) {
-      console.error("Failed to load restaurants", err);
+    setLoadError(null);
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        const data = await fetchRestaurants({ keyword: "restaurant" });
+        setRestaurants(data.results);
+        setNextPageToken(data.nextPageToken);
+        return;
+      } catch (err) {
+        lastError = err;
+        if (attempt < 2) await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+      }
     }
+    console.error("Failed to load restaurants", lastError);
+    setLoadError(
+      lastError instanceof Error ? lastError.message : "Couldn't reach the server"
+    );
   }, []);
 
   useEffect(() => {
@@ -250,7 +268,7 @@ export const App = () => {
     setSelectedRestaurantId(null);
     setSelectedRestaurantSnapshot(null);
     setSelectedRestaurantDetails(null);
-    setCurrentPage("discover");
+    setCurrentPage("decide");
   };
 
   const handleToggleFavorite = useCallback(
@@ -426,6 +444,16 @@ export const App = () => {
 
   const renderPage = () => {
     switch (currentPage) {
+      case "decide":
+        return (
+          <DecidePage
+            onSelectRestaurant={handleSelectRestaurant}
+            onToggleFavorite={handleToggleFavorite}
+            favorites={favoriteIds}
+            onCheckIn={handleCheckIn}
+            visitStats={visitStats}
+          />
+        );
       case "discover":
         return (
           <DiscoverPage
@@ -498,6 +526,21 @@ export const App = () => {
       <div className="flex h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-300">
         <Sidebar onNavigate={handleNavigate} currentPage={currentPage} />
         <div className="flex-1 flex flex-col overflow-y-auto bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
+          {loadError && (
+            <div className="mx-4 mt-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-800 dark:bg-red-500/10 dark:text-red-300">
+              <p className="font-medium">{loadError}</p>
+              <p className="mt-0.5 text-xs opacity-80">
+                The server sleeps when it has been quiet — it usually wakes within a minute.
+              </p>
+              <button
+                type="button"
+                onClick={loadRestaurants}
+                className="mt-2 rounded border border-red-300 px-3 py-1 text-xs font-semibold hover:bg-red-100 dark:border-red-500/40 dark:hover:bg-red-500/10"
+              >
+                Try again
+              </button>
+            </div>
+          )}
           {renderPage()}
         </div>
       </div>

--- a/frontend/src/api/restaurants.ts
+++ b/frontend/src/api/restaurants.ts
@@ -1,4 +1,5 @@
 import { Restaurant, RestaurantDetails, RestaurantReview } from "../../types";
+import { FALLBACK_IMAGE } from "../lib/fallbackImage";
 
 const API_BASE =
   typeof import.meta !== "undefined" && import.meta.env?.VITE_API_BASE_URL
@@ -63,7 +64,7 @@ export async function fetchRestaurantDetails(id: string): Promise<RestaurantDeta
     phone: data.phone ?? undefined,
     website: data.website ?? undefined,
     openingHours: Array.isArray(data.openingHours) ? data.openingHours : [],
-    imageUrl: data.imageUrl ?? "https://source.unsplash.com/600x400/?restaurant",
+    imageUrl: data.imageUrl ?? FALLBACK_IMAGE,
     photoUrls: Array.isArray(data.photoUrls) ? data.photoUrls : undefined,
     reviews: Array.isArray(data.reviews) ? data.reviews.map(mapReview) : [],
     googleMapsUrl: data.googleMapsUrl ?? undefined,
@@ -82,4 +83,61 @@ export interface MenuVisionSection {
 export interface MenuVisionResult {
   sections: MenuVisionSection[];
   raw?: string;
+}
+
+
+export interface DecideParams {
+  zip?: string;
+  lat?: number;
+  lng?: number;
+  minutes: number;
+  mode: "walk" | "drive";
+  kinds?: string[];
+  cuisines?: string[];
+  independent?: boolean;
+  openNow?: boolean;
+  maxPrice?: number | null;
+  dietary?: string[];
+  limit?: number;
+}
+
+export interface DecideResponse {
+  results: Restaurant[];
+  considered: number;
+  matchedTag: number;
+  budget: { minutes: number; mode: string; metres: number };
+}
+
+/** Ask the backend for a shortlist rather than a page of everything nearby. */
+export async function decideRestaurants(params: DecideParams): Promise<DecideResponse> {
+  const q = new URLSearchParams();
+  if (params.zip) q.append("zip", params.zip);
+  if (params.lat !== undefined && params.lng !== undefined) {
+    q.append("lat", String(params.lat));
+    q.append("lng", String(params.lng));
+  }
+  q.append("minutes", String(params.minutes));
+  q.append("mode", params.mode);
+  if (params.kinds?.length) q.append("kinds", params.kinds.join(","));
+  if (params.cuisines?.length) q.append("cuisines", params.cuisines.join(","));
+  if (params.dietary?.length) q.append("dietary", params.dietary.join(","));
+  if (params.independent) q.append("independent", "true");
+  if (params.openNow) q.append("openNow", "true");
+  if (params.maxPrice !== null && params.maxPrice !== undefined) {
+    q.append("maxPrice", String(params.maxPrice));
+  }
+  q.append("limit", String(params.limit ?? 8));
+
+  const response = await fetch(`${API_BASE}/decide?${q.toString()}`);
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.error || "Could not work out a shortlist");
+  }
+  const data = await response.json();
+  return {
+    results: Array.isArray(data.results) ? data.results : [],
+    considered: data.considered ?? 0,
+    matchedTag: data.matchedTag ?? 0,
+    budget: data.budget ?? { minutes: params.minutes, mode: params.mode, metres: 0 },
+  };
 }

--- a/frontend/src/components/AssistantChatWidget.tsx
+++ b/frontend/src/components/AssistantChatWidget.tsx
@@ -18,6 +18,7 @@ import {
   filterRestaurantsClientSide,
 } from "../utils/restaurantFilters";
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { FALLBACK_IMAGE } from "../lib/fallbackImage";
 
 type Props = {
   restaurants: Restaurant[];
@@ -26,7 +27,6 @@ type Props = {
   activeRestaurantDetails?: RestaurantDetails | null;
 };
 
-const FALLBACK_IMAGE = "https://source.unsplash.com/160x160/?restaurant,food";
 
 type ChatMessage = ChatHistoryItem & {
   recommendations?: RestaurantContextPayload[];

--- a/frontend/src/components/RestaurantCard.tsx
+++ b/frontend/src/components/RestaurantCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Heart } from "lucide-react";
 import { Restaurant } from "../../types";
+import { FALLBACK_IMAGE } from "../lib/fallbackImage";
 
 interface RestaurantCardProps {
   restaurant: Restaurant;
@@ -33,8 +34,15 @@ export const RestaurantCard = ({
 }: RestaurantCardProps) => {
   const { imageUrl, name, rating, reviewCount, address, priceLevel, types, isFavorite, businessStatus, openNow, dietary } =
     restaurant;
-  const resolvedImageUrl = imageUrl || "https://source.unsplash.com/400x300/?restaurant,food";
+  const { reasons, matchScore } = restaurant;
+  const resolvedImageUrl = imageUrl || FALLBACK_IMAGE;
   const formattedVisitDate = formatLastVisit(lastVisited);
+  const scoreBadge =
+    typeof matchScore === "number" ? (
+      <span className="absolute left-2 top-2 rounded-full bg-emerald-600/95 px-2 py-0.5 text-xs font-semibold text-white shadow">
+        {matchScore}% match
+      </span>
+    ) : null;
 
   return (
     <div
@@ -50,11 +58,12 @@ export const RestaurantCard = ({
           className="object-cover w-full h-48"
           onError={(e) => {
             const target = e.currentTarget as HTMLImageElement;
-            if (target.src !== "https://source.unsplash.com/400x300/?restaurant,food") {
-              target.src = "https://source.unsplash.com/400x300/?restaurant,food";
+            if (target.src !== FALLBACK_IMAGE) {
+              target.src = FALLBACK_IMAGE;
             }
           }}
         />
+        {scoreBadge}
 
         {businessStatus !== "OPERATIONAL" && (
           <div className="absolute px-2 py-1 text-xs font-medium text-white bg-red-500 rounded top-2 left-2">
@@ -122,6 +131,31 @@ export const RestaurantCard = ({
             ))}
           </div>
         )}
+
+        {/* Why this made the shortlist. Shown for /decide results only, and it
+            distinguishes what we know from what OSM never recorded — an
+            "unknown" chip is not a negative, and pretending otherwise is how a
+            recommender starts lying. */}
+        {reasons?.length ? (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {reasons.map((reason, i) => (
+              <span
+                key={`${reason.label}-${i}`}
+                className={
+                  "rounded-full px-2 py-0.5 text-xs font-medium " +
+                  (reason.kind === "match" || reason.kind === "bonus"
+                    ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300"
+                    : reason.kind === "unknown"
+                    ? "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                    : "bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300")
+                }
+              >
+                {reason.kind === "unknown" ? "? " : ""}
+                {reason.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
 
         {(onCheckIn || visited) && (
           <div className="mt-3 flex flex-wrap items-center gap-2">

--- a/frontend/src/lib/fallbackImage.ts
+++ b/frontend/src/lib/fallbackImage.ts
@@ -1,0 +1,17 @@
+/* source.unsplash.com was the fallback everywhere in this app and was
+ * discontinued — it now answers 503, so every "missing image" placeholder was
+ * itself a broken image. The backend already serves a real cover photo or its
+ * own SVG from /place-photo/:id, so this is only the last resort when even
+ * that URL is absent. Inline, so it cannot 503 either. */
+export const FALLBACK_IMAGE =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img" aria-label="No photo available">
+      <rect width="400" height="300" fill="#f1f5f9"/>
+      <g fill="none" stroke="#94a3b8" stroke-width="6" stroke-linecap="round">
+        <path d="M150 130v60M150 130a14 14 0 0 1 28 0v22a14 14 0 0 1-28 0z"/>
+        <path d="M232 190v-60c14 0 22 10 22 24s-8 18-22 18"/>
+      </g>
+      <text x="200" y="232" font-family="system-ui,sans-serif" font-size="15" fill="#94a3b8" text-anchor="middle">No photo yet</text>
+    </svg>`
+  );

--- a/frontend/src/sections/MainContent/DecidePage.tsx
+++ b/frontend/src/sections/MainContent/DecidePage.tsx
@@ -1,0 +1,303 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Restaurant, VisitStatsMap } from "../../../types";
+import { RestaurantCard } from "../../components/RestaurantCard";
+import { decideRestaurants, DecideParams } from "../../api/restaurants";
+
+/* The decision screen.
+ *
+ * This replaces "Trending Restaurants", which ranked nothing: OpenStreetMap
+ * carries no ratings or review counts, so every result came back with rating 0
+ * and the heading was writing a cheque the data could not cash.
+ *
+ * What the data *can* support is a constraint problem. Distance, venue kind,
+ * cuisine and chain-vs-independent are on essentially every record, so they
+ * filter. Hours, price and dietary tags are on a quarter, a third and one
+ * percent respectively, so they rank and are labelled — never excluded. The
+ * answer is a shortlist with its reasoning attached rather than a thousand
+ * rows sorted by nothing. */
+
+type Props = {
+  onSelectRestaurant: (restaurant: Restaurant) => void;
+  onToggleFavorite: (id: string) => void;
+  favorites: string[];
+  onCheckIn: (restaurant: Restaurant) => void;
+  visitStats: VisitStatsMap;
+};
+
+const KINDS = [
+  { id: "restaurant", label: "Sit down" },
+  { id: "fast_food", label: "Fast food" },
+  { id: "cafe", label: "Café" },
+  { id: "bar", label: "Bar" },
+  { id: "dessert", label: "Dessert" },
+];
+
+const CUISINES = [
+  "pizza", "burger", "american", "chinese", "sandwich",
+  "mexican", "italian", "chicken", "japanese", "thai",
+];
+
+const DIETARY = [
+  { id: "vegan", label: "Vegan" },
+  { id: "vegetarian", label: "Vegetarian" },
+  { id: "gluten_free", label: "Gluten free" },
+  { id: "halal", label: "Halal" },
+];
+
+const toggle = (list: string[], value: string) =>
+  list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+
+const Chip = ({
+  active, onClick, children,
+}: { active: boolean; onClick: () => void; children: React.ReactNode }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    className={
+      "rounded-full border px-3 py-1.5 text-sm font-medium transition " +
+      (active
+        ? "border-emerald-600 bg-emerald-600 text-white"
+        : "border-gray-300 text-gray-700 hover:border-emerald-400 dark:border-gray-600 dark:text-gray-200")
+    }
+  >
+    {children}
+  </button>
+);
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="mb-5">
+    <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {label}
+    </p>
+    {children}
+  </div>
+);
+
+export const DecidePage = ({
+  onSelectRestaurant, onToggleFavorite, favorites, onCheckIn, visitStats,
+}: Props) => {
+  const [zip, setZip] = useState("18104");
+  const [minutes, setMinutes] = useState(15);
+  const [mode, setMode] = useState<"walk" | "drive">("drive");
+  const [kinds, setKinds] = useState<string[]>([]);
+  const [cuisines, setCuisines] = useState<string[]>([]);
+  const [dietary, setDietary] = useState<string[]>([]);
+  const [openNow, setOpenNow] = useState(false);
+  /* On by default. With no filters the shortlist is Subway, Dunkin' and
+     McDonald's — technically the closest, and the least useful answer this app
+     could give. Independent-only is the one thing it does that Maps will not,
+     so it leads with it; the chip turns it off in one click. */
+  const [independent, setIndependent] = useState(true);
+
+  const [results, setResults] = useState<Restaurant[]>([]);
+  const [considered, setConsidered] = useState(0);
+  const [matchedTag, setMatchedTag] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [waking, setWaking] = useState(false);
+
+  const search = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const params: DecideParams = {
+      zip: zip || undefined, minutes, mode, kinds, cuisines, dietary,
+      openNow, independent, limit: 9,
+    };
+
+    /* The backend sleeps on Render's free tier, so the first call after an idle
+       spell can take half a minute or simply fail. The old code caught that
+       error, logged it, and left an empty list on screen forever — which is
+       why this app looked broken to anyone who arrived first. Retry, and say
+       what is happening while we do. */
+    const wakeTimer = setTimeout(() => setWaking(true), 2500);
+    try {
+      let lastError: unknown = null;
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+          const data = await decideRestaurants(params);
+          setResults(data.results);
+          setConsidered(data.considered);
+          setMatchedTag(data.matchedTag);
+          return;
+        } catch (err) {
+          lastError = err;
+          if (attempt < 2) await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+        }
+      }
+      throw lastError;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      clearTimeout(wakeTimer);
+      setWaking(false);
+      setLoading(false);
+    }
+  }, [zip, minutes, mode, kinds, cuisines, dietary, openNow, independent]);
+
+  // One shortlist on arrival, so the page is never an empty shell.
+  useEffect(() => {
+    search();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const askedForTag = dietary.length > 0;
+
+  return (
+    <div className="px-4 py-6 md:px-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 md:text-3xl">
+          Where should we eat?
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Set the constraints. We'll narrow {considered ? `${considered} places` : "the valley"} down
+          to a handful and show why each one made it.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+        {/* -- the constraints ------------------------------------------- */}
+        <form
+          className="h-fit rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900"
+          onSubmit={(e) => { e.preventDefault(); search(); }}
+        >
+          <Field label="Starting from">
+            <input
+              value={zip}
+              onChange={(e) => setZip(e.target.value.replace(/\D/g, "").slice(0, 5))}
+              inputMode="numeric"
+              placeholder="ZIP code"
+              aria-label="ZIP code"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            />
+          </Field>
+
+          <Field label={`Within ${minutes} min ${mode}`}>
+            <div className="mb-3 flex gap-2">
+              <Chip active={mode === "walk"} onClick={() => setMode("walk")}>Walk</Chip>
+              <Chip active={mode === "drive"} onClick={() => setMode("drive")}>Drive</Chip>
+            </div>
+            <input
+              type="range" min={5} max={40} step={5}
+              value={minutes}
+              onChange={(e) => setMinutes(Number(e.target.value))}
+              aria-label="Travel time in minutes"
+              className="w-full accent-emerald-600"
+            />
+          </Field>
+
+          <Field label="Kind of place">
+            <div className="flex flex-wrap gap-2">
+              {KINDS.map((k) => (
+                <Chip key={k.id} active={kinds.includes(k.id)} onClick={() => setKinds(toggle(kinds, k.id))}>
+                  {k.label}
+                </Chip>
+              ))}
+            </div>
+          </Field>
+
+          <Field label="Craving">
+            <div className="flex flex-wrap gap-2">
+              {CUISINES.map((c) => (
+                <Chip key={c} active={cuisines.includes(c)} onClick={() => setCuisines(toggle(cuisines, c))}>
+                  {c.replace(/_/g, " ")}
+                </Chip>
+              ))}
+            </div>
+          </Field>
+
+          <Field label="Dietary">
+            <div className="flex flex-wrap gap-2">
+              {DIETARY.map((d) => (
+                <Chip key={d.id} active={dietary.includes(d.id)} onClick={() => setDietary(toggle(dietary, d.id))}>
+                  {d.label}
+                </Chip>
+              ))}
+            </div>
+          </Field>
+
+          <Field label="Only show">
+            <div className="flex flex-wrap gap-2">
+              <Chip active={openNow} onClick={() => setOpenNow(!openNow)}>Open now</Chip>
+              <Chip active={independent} onClick={() => setIndependent(!independent)}>Independent</Chip>
+            </div>
+          </Field>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-60"
+          >
+            {loading ? "Working it out…" : "Find us somewhere"}
+          </button>
+        </form>
+
+        {/* -- the shortlist ---------------------------------------------- */}
+        <section>
+          {waking && (
+            <p className="mb-4 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-300">
+              Waking the server — it sleeps when nobody's been by for a while. One moment.
+            </p>
+          )}
+
+          {error && (
+            <div className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-800 dark:bg-red-500/10 dark:text-red-300">
+              <p className="font-medium">{error}</p>
+              <button
+                type="button"
+                onClick={search}
+                className="mt-2 rounded border border-red-300 px-3 py-1 text-xs font-semibold hover:bg-red-100 dark:border-red-500/40 dark:hover:bg-red-500/10"
+              >
+                Try again
+              </button>
+            </div>
+          )}
+
+          {askedForTag && !loading && !error && (
+            /* Say how thin the tag data is rather than implying the shortlist
+               is the whole truth. Nine vegan-tagged places in the valley is a
+               fact about OpenStreetMap, not about the valley. */
+            <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+              {matchedTag} nearby {matchedTag === 1 ? "place is" : "places are"} actually tagged{" "}
+              {dietary.map((d) => d.replace(/_/g, " ")).join(" / ")} on OpenStreetMap. Those come
+              first; the rest simply aren't tagged either way.
+            </p>
+          )}
+
+          {!loading && !error && results.length === 0 && (
+            <div className="rounded-xl border border-dashed border-gray-300 p-10 text-center dark:border-gray-700">
+              <p className="font-medium text-gray-700 dark:text-gray-200">Nothing fits all of that.</p>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Try widening the travel time, or dropping a filter.
+              </p>
+            </div>
+          )}
+
+          {results.length > 0 && (
+            <>
+              <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+                {results.length} of {considered} that fit — best match first.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {results.map((restaurant) => (
+                  <RestaurantCard
+                    key={restaurant.id}
+                    restaurant={{ ...restaurant, isFavorite: favorites.includes(restaurant.id) }}
+                    onClick={() => onSelectRestaurant(restaurant)}
+                    onFavorite={() => onToggleFavorite(restaurant.id)}
+                    visited={Boolean(visitStats[restaurant.id])}
+                    visitCount={visitStats[restaurant.id]?.count}
+                    lastVisited={visitStats[restaurant.id]?.lastVisited}
+                    onCheckIn={() => onCheckIn(restaurant)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default DecidePage;

--- a/frontend/src/sections/MainContent/RestaurantDetailsPage.tsx
+++ b/frontend/src/sections/MainContent/RestaurantDetailsPage.tsx
@@ -3,6 +3,7 @@ import { Restaurant, RestaurantDetails, VisitStatsEntry } from "../../../types";
 import { Heart, Globe, Phone, Navigation, MapPin, CheckCircle2, Sparkles } from "lucide-react";
 import { StatusBanner } from "../../components/StatusBanner";
 import { askAssistant, ComparisonResult, RestaurantContextPayload } from "../../api/assistant";
+import { FALLBACK_IMAGE } from "../../lib/fallbackImage";
 
 export interface RestaurantDetailsPageProps {
   restaurantId: string;
@@ -365,7 +366,7 @@ export const RestaurantDetailsPage: React.FC<RestaurantDetailsPageProps> = ({
 
   const totalPhotos = photoSources.length;
   const hasMultiplePhotos = totalPhotos > 1;
-  const currentPhoto = photoSources[photoIndex] ?? display?.imageUrl ?? "https://source.unsplash.com/600x400/?restaurant";
+  const currentPhoto = photoSources[photoIndex] ?? display?.imageUrl ?? FALLBACK_IMAGE;
 
   const showPrevPhoto = () => {
     if (!hasMultiplePhotos) return;
@@ -398,7 +399,7 @@ export const RestaurantDetailsPage: React.FC<RestaurantDetailsPageProps> = ({
     const payload: Restaurant = {
       id: display.id,
       name: display.name,
-      imageUrl: display.imageUrl || fallbackRestaurant?.imageUrl || "https://source.unsplash.com/400x300/?restaurant,food",
+      imageUrl: display.imageUrl || fallbackRestaurant?.imageUrl || FALLBACK_IMAGE,
       rating: display.rating,
       reviewCount: display.reviewCount,
       address: display.address,

--- a/frontend/src/sections/Sidebar/Sidebar.tsx
+++ b/frontend/src/sections/Sidebar/Sidebar.tsx
@@ -9,8 +9,13 @@ interface SidebarProps {
 
 const navItems = [
   {
+    key: "decide",
+    label: "Decide",
+    icon: <Sparkles size={20} />,
+  },
+  {
     key: "discover",
-    label: "Discover",
+    label: "Browse all",
     icon: <Search size={20} />,
   },
   {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -1,3 +1,12 @@
+/** Why a place made the shortlist. `unknown` is a first-class outcome: OSM
+ *  simply has no dietary tag for most places, and saying so is more useful
+ *  than implying a "no". */
+export interface MatchReason {
+  kind: "match" | "bonus" | "unknown" | "miss";
+  label: string;
+  weight: number;
+}
+
 export interface Restaurant {
   id: string;
   name: string;
@@ -14,6 +23,12 @@ export interface Restaurant {
   hasVisited?: boolean;
   visitCount?: number;
   lastVisited?: string | null;
+  /* Present only on results from /decide. */
+  minutes?: number;
+  metres?: number;
+  matchScore?: number;
+  reasons?: MatchReason[];
+  independent?: boolean;
 }
 
 export interface RestaurantReview {


### PR DESCRIPTION
## Why

"Trending Restaurants" ranked nothing. OSM carries no ratings and no review counts, so every card came back `rating: 0` — the heading was writing a cheque the data couldn't cash. Losing the Places key didn't break a good product so much as remove the veneer over a positioning problem: as a Maps clone, this was always going to lose to Maps.

What the data *can* support is a constraint problem — and that's something Maps is genuinely bad at. *Four people, one vegan, nothing over 15 minutes away, open now, no chains.* You can't stack those filters anywhere else.

## The rule the solver is built on

Field coverage across the 1,032 baked places decides what's honest:

| Filters on | Ranks only |
|---|---|
| `lat`/`lng`, `types` (100%) | `priceLevel` (29%) |
| `cuisine` (66%) | `openingHours` (25%) |
| `brand` → independent (72%) | `dietary` (1%) · `wheelchair` (0%) |

**Sparse attributes rank; they never exclude.** Filtering on `dietary` would answer "there is nowhere vegan in the Lehigh Valley" — confidently and wrongly, off nine records. A requested-but-missing tag shows as `? vegan not listed` rather than being silently zeroed or dropped. The one exception is a *known* negative: if OSM says a place is closed and you asked for open, that's real information and it goes.

Every result carries its reasoning, and the weights sum to 1 so the score reads as a percentage.

## Two things the first build got wrong

Both caught by actually running it against the real dataset:

- **Asking for vegan returned McDonald's at rank two**, on the strength of being close and well-described. A 15% bonus can't outweigh proximity — so a requested tag is now a *tier*, not a nudge.
- **A four-item shortlist came back as three Chipotles.** Chains now get one slot (nearest branch); independents have no brand and are never collapsed.

Independent-only defaults **on**: with no filters the honest answer is Subway, Dunkin' and McDonald's — correct, and the least useful thing this app could say. One click turns it off.

## Two bugs that made it look broken

- **The on-mount fetch swallowed its error** (`catch` → `console.error` → empty list, no retry, runs once). On Render's free tier the first request after idle fails, so the first visitor got "Page 0 of 0" *forever*. Now retries with backoff and surfaces a Try again.
- **Every fallback image pointed at `source.unsplash.com`**, which was discontinued and returns 503 — the "missing image" placeholder was itself a broken image, in six places. Now an inline SVG.

## Tests

16 tests over the solver, most guarding the sparse-attribute rule, wired into CI — which previously ran none. Also dropped the leftover `GOOGLE_PLACES_API_KEY: dummy-key` from the workflow; nothing reads it.

## Reviewer notes

- `Sidebar/components/SidebarMenu.tsx` appears to be **dead code** — nothing imports it. I edited the live `Sidebar/Sidebar.tsx` instead and reverted my change to the dead one, but it's probably worth deleting separately.
- `frontend/.env` is listed in `.gitignore` but is **tracked**, so it isn't actually ignored. Worth `git rm --cached`.
- Verified end to end against the real 1,032-place dataset: backend build + 16 tests pass, frontend builds, and the flow was driven in a browser.