### PR TITLE
Make ZIP search work anywhere in the US

### DIFF
--- a/backend/areas.js
+++ b/backend/areas.js
@@ -24,6 +24,10 @@ const MAX_MEMORY_AREAS = 40;
 // slice to the search centre and discard the rest.
 const MAX_PLACES_PER_AREA = 1500;
 const DEFAULT_RADIUS = 20000;
+// How far inside the baked footprint a search has to be to be answered from it.
+// Results are paged 20 at a time nearest-first, so a few km of cover around the
+// search point is plenty; this only rules out searches sitting on the edge.
+const EDGE_MARGIN = 3000;
 
 let zips = null;
 const memory = new Map();                     // key -> { center, places, at }
@@ -106,10 +110,22 @@ export async function areaFor({ lat, lng, radius = DEFAULT_RADIUS }, baked) {
 
   if (baked?.places?.length) {
     const home = baked.center;
-    // Inside the baked footprint (minus a margin so edge searches still get a
-    // full ring of results) the local dataset is strictly better: instant.
-    if (distanceKm(home, center) * 1000 < Math.max(0, (baked.radiusMeters ?? DEFAULT_RADIUS) - radius / 2)) {
-      return { center: home, places: baked.places, source: "local" };
+    // Inside the baked footprint the local dataset is strictly better: it is
+    // instant, and it cannot be rate-limited. Only the outer ring is excluded,
+    // where a search would be missing the half of its neighbourhood that falls
+    // outside the bake.
+    //
+    // The old margin was radius/2 -- half the *search* radius, not the bake's.
+    // With both at 20km that admitted only the inner 10km, which put Bethlehem
+    // (10.4-10.7km out) on the live path: the app's own home city queried
+    // Overpass for restaurants that were already sitting in memory.
+    const bakedRadius = baked.radiusMeters ?? DEFAULT_RADIUS;
+    if (distanceKm(home, center) * 1000 <= Math.max(0, bakedRadius - EDGE_MARGIN)) {
+      // Centre on what was actually searched, not on home. searchPlaces filters
+      // by distance from this point, so returning `home` here made every ZIP in
+      // the valley return the same Allentown-centred list -- the ZIP the visitor
+      // typed changed nothing.
+      return { center, places: baked.places, source: "local" };
     }
   }
 

--- a/backend/osm.js
+++ b/backend/osm.js
@@ -18,9 +18,17 @@ const AMENITIES = "restaurant|cafe|fast_food|bar|pub|ice_cream";
 // trimming afterwards is far too late.
 export const ELEMENT_CAP = 2500;
 
+// Overpass's own [timeout:] governs how long *it* will spend on the query. It
+// says nothing about a mirror that accepts the connection and then stops
+// talking, and fetch() without a signal waits for that forever. Three mirrors
+// tried in turn meant one request could hang indefinitely, holding a worker
+// open until the host killed it -- which is what a visitor saw as a 502.
+const ENDPOINT_TIMEOUT_MS = 25000;
+const QUERY_TIMEOUT_S = 20;
+
 export function overpassQuery(lat, lng, radius, cap = ELEMENT_CAP) {
   return `
-[out:json][timeout:60];
+[out:json][timeout:${QUERY_TIMEOUT_S}];
 (
   node["amenity"~"^(${AMENITIES})$"](around:${radius},${lat},${lng});
   way ["amenity"~"^(${AMENITIES})$"](around:${radius},${lat},${lng});
@@ -33,16 +41,29 @@ export async function fetchElements(lat, lng, radius, { log = () => {}, cap = EL
   for (const url of ENDPOINTS) {
     try {
       log(`  querying ${new URL(url).host}… `);
-      const res = await fetch(url, {
-        method: "POST",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          "user-agent": "dinevalley/1.0 (portfolio project)",
-        },
-        body: new URLSearchParams({ data: overpassQuery(lat, lng, radius, cap) }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
+      const abort = new AbortController();
+      const timer = setTimeout(() => abort.abort(), ENDPOINT_TIMEOUT_MS);
+      let json;
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "user-agent": "dinevalley/1.0 (portfolio project)",
+          },
+          body: new URLSearchParams({ data: overpassQuery(lat, lng, radius, cap) }),
+          signal: abort.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        // Reading the body can hang too, so it stays inside the timeout.
+        json = await res.json();
+      } catch (err) {
+        throw abort.signal.aborted
+          ? new Error(`no answer in ${ENDPOINT_TIMEOUT_MS / 1000}s`)
+          : err;
+      } finally {
+        clearTimeout(timer);
+      }
 
       // Overpass reports overload in-band: HTTP 200 with a `remark` and no
       // elements. Taking that at face value looks exactly like "this area has

--- a/backend/server.js
+++ b/backend/server.js
@@ -222,8 +222,33 @@ app.get("/decide", async (req, res) => {
     const travelMode = mode === "walk" ? "walk" : "drive";
     const maxMinutes = Math.min(60, Math.max(1, Number(minutes) || 15));
 
+    /* Load the places around wherever they're starting from.
+     *
+     * This used to hand the solver meta().dataset.places unconditionally -- the
+     * baked Lehigh Valley -- and only move `center`. So a ZIP anywhere else was
+     * measuring the travel budget against restaurants a continent away, every
+     * one of them fell outside it, and the page said "Nothing fits all of that"
+     * as though the filters were too tight. /restaurants already did this; the
+     * page visitors actually land on did not.
+     *
+     * The area is fetched at the default radius rather than at the travel
+     * budget, so this shares one cached neighbourhood with /restaurants instead
+     * of asking Overpass a second, differently-sized question about the same
+     * place. The budget is a filter the solver applies on top. */
+    let area = null;
+    try {
+      area = await areaFor({ ...center }, meta().dataset);
+    } catch (err) {
+      if (err.code === "AREA_UNAVAILABLE") {
+        return res.status(503).json({
+          error: "Couldn't load restaurants for that area just now — OpenStreetMap is busy. Try again in a moment.",
+        });
+      }
+      throw err;
+    }
+
     const { results, considered, matchedTag } = decide({
-      places: meta().dataset.places,
+      places: area?.places?.length ? area.places : meta().dataset.places,
       center,
       maxMinutes,
       mode: travelMode,

--- a/frontend/src/api/restaurants.ts
+++ b/frontend/src/api/restaurants.ts
@@ -32,7 +32,14 @@ export async function fetchRestaurants(filters: BackendFilters): Promise<Restaur
   if (filters.zip) params.append("zip", filters.zip);
 
   const response = await fetch(`${API_BASE}/restaurants?${params.toString()}`);
-  if (!response.ok) throw new Error("Failed to fetch restaurants");
+  if (!response.ok) {
+    // The server says something useful here -- which ZIP it has no centroid
+    // for, or that OpenStreetMap is busy and this is worth retrying. Replacing
+    // that with "Failed to fetch restaurants" told the visitor nothing and made
+    // a temporary problem look permanent.
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.error || "Failed to fetch restaurants");
+  }
 
   const data = await response.json();
 

--- a/frontend/src/sections/MainContent/DecidePage.tsx
+++ b/frontend/src/sections/MainContent/DecidePage.tsx
@@ -150,7 +150,7 @@ export const DecidePage = ({
           Where should we eat?
         </h1>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Set the constraints. We'll narrow {considered ? `${considered} places` : "the valley"} down
+          Set the constraints. We'll narrow {considered ? `${considered} places` : "what's around you"} down
           to a handful and show why each one made it.
         </p>
       </header>

--- a/frontend/src/sections/MainContent/components/FilterModel.tsx
+++ b/frontend/src/sections/MainContent/components/FilterModel.tsx
@@ -157,7 +157,7 @@ export const FilterModel: React.FC<FilterModelProps> = ({
               className="w-full accent-indigo-500"
             />
             <p className="mt-1 text-xs text-gray-500">
-              Adjust to search within a specific radius of the Lehigh Valley.
+              Adjust to search within a specific radius of the ZIP you start from.
             </p>
           </div>
 


### PR DESCRIPTION
Typing a ZIP outside the Lehigh Valley found nothing, and the page blamed the filters: **"Nothing fits all of that."** Four separate bugs, and the worst was on the page visitors land on by default.

## The bugs

**1. `/decide` never loaded an area.** It passed the baked Lehigh Valley dataset to the solver unconditionally and only moved `center`, so a ZIP in Portland measured its travel budget against restaurants in Pennsylvania. Everything fell outside it and the shortlist came back empty. `/restaurants` had been doing this correctly for months; the default page never did.

**2. Bethlehem queried the network for restaurants already in memory.** The baked-region shortcut required `distance < bakedRadius − searchRadius/2` — with both at 20km that admitted only the inner 10km, and 18015/18017 sit at 10.67km and 10.43km. The margin is now measured against the bake, not the search.

**3. Every valley ZIP returned an identical list.** The baked path returned the *home* centre, and `searchPlaces` filters by distance from `area.center` — so the ZIP someone typed changed nothing. It now returns the centre actually searched.

**4. Nothing bounded the Overpass fetch.** `[out:json][timeout:60]` governs how long Overpass spends on the query; it says nothing about a mirror that accepts the connection and then stops talking, and `fetch()` without a signal waits forever — across three mirrors in turn. **This is what production was serving as a 502**, with the worker held open until the host killed it. I reproduced it against the live backend before changing anything: 503 on the home ZIP, then 502s, then instant 502s as the process died. Each endpoint now aborts at 25s.

`/decide` also fetches at the default radius rather than the travel budget, so it shares one cached neighbourhood with `/restaurants` instead of asking Overpass a second, differently-sized question about the same place.

## Verified

| ZIP | Before | After |
|---|---|---|
| 97201 Portland | 0 results | 9 of 1392 |
| 02139 Cambridge | rate-limited failure | 9 of 1500, **40ms** (shared cache) |
| 90210 Beverly Hills | 502 in production | 9 of 1261 |
| 18015 Bethlehem | live Overpass query | instant, served locally |

Also confirmed in the browser: typing `97201` returns real Portland addresses. Backend tests 16/16, frontend builds.

## For the reviewer

- **A cold ZIP can still fail** when the Overpass mirrors are rate-limiting — as a retryable 503 that says so, rather than a crash. The shared cache makes this much rarer.
- **Result ordering is unchanged.** `searchPlaces` still sorts by tag completeness (the documented stand-in for Google's "prominence"), not distance, so two nearby ZIPs can look similar even though the underlying sets differ. That's a deliberate design decision, so I left it alone — happy to make distance a tiebreaker in a follow-up.
- The frontend commit is separable: it surfaces the server's specific error instead of a generic string, and drops two bits of copy still promising the Lehigh Valley.